### PR TITLE
Fix monster action stitching call signature

### DIFF
--- a/monster_formatter.py
+++ b/monster_formatter.py
@@ -137,6 +137,7 @@ class MonsterFormatter:
         else:
             # Try stitch (non-fatal)
             stitched = maybe_stitch_monster_actions(
+                None,
                 text,
                 meta=meta,
             )


### PR DESCRIPTION
## Summary
- call maybe_stitch_monster_actions with explicit `None` preferred argument in monster formatter

## Testing
- `pytest tests/test_smoke.py` *(fails: ModuleNotFoundError: No module named 'llama_index.vector_stores')*

------
https://chatgpt.com/codex/tasks/task_e_6898356c61cc8327834e1b00ff4b2e7d