### PR TITLE
Fix monster stitcher call to use NodeWithScore

### DIFF
--- a/query_router.py
+++ b/query_router.py
@@ -462,7 +462,7 @@ def run_query(
                 if query_type == "monster":
                     # Stitch using the actual text plus node metadata (not the NodeWithScore itself)
                     pref_meta = _node_meta(preferred)
-                    stitched = maybe_stitch_monster_actions(raw_text, meta=pref_meta)
+                    stitched = maybe_stitch_monster_actions(preferred, raw_text, meta=pref_meta)
                     if stitched:
                         raw_text = stitched
             else:


### PR DESCRIPTION
## Summary
- pass full `preferred` node into `maybe_stitch_monster_actions` to avoid `NodeWithScore` errors

## Testing
- `pytest tests/test_smoke.py::test_monster_booyahg_formatted_output -q` *(fails: ModuleNotFoundError: No module named 'llama_index.vector_stores')*

------
https://chatgpt.com/codex/tasks/task_e_6898357a63dc832790b7b1e0e83f8eee