### PR TITLE
Ensure exact single-token match is top result

### DIFF
--- a/query_router.py
+++ b/query_router.py
@@ -227,7 +227,17 @@ def rerank(query, hits):
 
         return s
 
-    return sorted(hits, key=score, reverse=True)
+    sorted_hits = sorted(hits, key=score, reverse=True)
+
+    if single and qtok:
+        for idx, h in enumerate(sorted_hits):
+            name = (_node_meta(h).get("name") or "")
+            if _norm(name) == qtok:
+                if idx != 0:
+                    sorted_hits.insert(0, sorted_hits.pop(idx))
+                break
+
+    return sorted_hits
 
 def covers_all(r, rare_tokens):
     meta = _node_meta(r)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -18,6 +18,24 @@ def test_monster_goblin_top(embedder):
     meta = _node_meta(hits[0])
     assert meta["name"].lower() == "goblin"
 
+
+def test_rerank_exact_name_bubble():
+    class Node:
+        def __init__(self, name):
+            self.metadata = {"name": name}
+            self.text = name
+
+    class Hit:
+        def __init__(self, name, score):
+            self.node = Node(name)
+            self.score = score
+
+    hits = [Hit("goblin boss", 0), Hit("goblin", -100)]
+    results = rerank("goblin", hits)
+    names = [(_node_meta(h).get("name") or "").lower() for h in results]
+    assert names[0] == "goblin"
+    assert names[1] == "goblin boss"
+
 def test_monster_booyahg_whip(embedder):
     hits = retrieve_with_backoff("grim_bestiary", embedder, "booyahg whip", "booyahg")
     hits = rerank("booyahg whip", hits)


### PR DESCRIPTION
## Summary
- bubble exact normalized name to the front of reranked hits for single-token queries
- add unit test covering single-token post-processing

## Testing
- `pytest tests/test_smoke.py::test_rerank_exact_name_bubble -q` *(fails: No module named 'llama_index.vector_stores')*
- `pip install llama-index-vector-stores-chroma -q` *(fails: 403 Client Error)*

------
https://chatgpt.com/codex/tasks/task_e_68991186ff888327b32440bed14be19d