### PR TITLE
Add monster JSON sidecar and schema

### DIFF
--- a/schemas/monster.json
+++ b/schemas/monster.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Monster",
+  "type": "object",
+  "required": [
+    "name",
+    "source",
+    "ac",
+    "hp",
+    "speed",
+    "str",
+    "dex",
+    "con",
+    "int",
+    "wis",
+    "cha",
+    "traits",
+    "actions",
+    "reactions",
+    "provenance"
+  ],
+  "properties": {
+    "name": {"type": "string"},
+    "source": {"type": "string"},
+    "ac": {"type": "string"},
+    "hp": {"type": "string"},
+    "speed": {"type": "string"},
+    "str": {"type": "integer"},
+    "dex": {"type": "integer"},
+    "con": {"type": "integer"},
+    "int": {"type": "integer"},
+    "wis": {"type": "integer"},
+    "cha": {"type": "integer"},
+    "traits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "text"],
+        "properties": {
+          "name": {"type": "string"},
+          "text": {"type": "string"}
+        }
+      }
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "text"],
+        "properties": {
+          "name": {"type": "string"},
+          "text": {"type": "string"}
+        }
+      }
+    },
+    "reactions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "text"],
+        "properties": {
+          "name": {"type": "string"},
+          "text": {"type": "string"}
+        }
+      }
+    },
+    "provenance": {"type": "array"}
+  }
+}
+

--- a/tests/test_monster_json.py
+++ b/tests/test_monster_json.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+
+import jsonschema
+
+from query_router import run_query, LAST_MONSTER_JSON
+
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schemas" / "monster.json"
+with open(SCHEMA_PATH) as f:
+    MONSTER_SCHEMA = json.load(f)
+
+def _names(items):
+    return [i["name"] for i in items]
+
+def test_goblin_sidecar(embedder):
+    run_query(type="monster", query="goblin", embed_model=embedder)
+    data = LAST_MONSTER_JSON
+    assert data["name"].lower() == "goblin"
+    assert data["ac"].startswith("15")
+    assert data["hp"].startswith("7")
+    assert data["speed"].startswith("30")
+    assert data["str"] == 8
+    assert data["dex"] == 14
+    assert data["con"] == 10
+    assert data["int"] == 10
+    assert data["wis"] == 8
+    assert data["cha"] == 8
+    assert "Nimble Escape" in _names(data["traits"])
+    assert "Scimitar" in _names(data["actions"])
+    assert "Shortbow" in _names(data["actions"])
+    assert data["reactions"] == []
+    jsonschema.validate(data, MONSTER_SCHEMA)
+
+
+def test_goblin_boss_sidecar(embedder):
+    run_query(type="monster", query="goblin boss", embed_model=embedder)
+    data = LAST_MONSTER_JSON
+    assert data["name"].lower() == "goblin boss"
+    assert data["ac"].startswith("17")
+    assert data["hp"].startswith("21")
+    assert data["str"] == 10
+    assert data["dex"] == 14
+    assert "Nimble Escape" in _names(data["traits"])
+    assert "Multiattack" in _names(data["actions"])
+    assert any(r["name"] == "Redirect Attack" for r in data["reactions"])
+    jsonschema.validate(data, MONSTER_SCHEMA)


### PR DESCRIPTION
## Summary
- parse monster markdown into structured JSON via `monster_to_json`
- expose last monster query as `LAST_MONSTER_JSON`
- validate monsters against new `schemas/monster.json`
- add sidecar tests for Goblin and Goblin Boss

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68993fe118f4832799ea4beb42ce6905