### PR TITLE
Include provenance field in fallback monster data

### DIFF
--- a/query_router.py
+++ b/query_router.py
@@ -101,6 +101,7 @@ FALLBACK_MONSTERS: dict[str, dict] = {
             },
         ],
         "reactions": [],
+        "provenance": [],
     },
     "goblin boss": {
         "name": "Goblin Boss",
@@ -140,6 +141,7 @@ FALLBACK_MONSTERS: dict[str, dict] = {
                 "text": "When a creature the goblin can see targets it with an attack, the goblin chooses another goblin within 5 ft. of it; the two goblins swap places, and the chosen goblin becomes the target instead.",
             }
         ],
+        "provenance": [],
     },
 }
 


### PR DESCRIPTION
## Summary
- ensure fallback monster stat blocks include a `provenance` list so they conform to the monster schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899519279048327a1a3a861b5160378