### PR TITLE
feat: unify run_query output with sidecar tuple

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
+import argparse
 import csv
+import json
 from datetime import datetime
 from pathlib import Path
 from llama_index.core.settings import Settings
@@ -55,7 +57,12 @@ log_entries.append({
     "status": modelLlmMsg
 })
 
-force = False
+parser = argparse.ArgumentParser()
+parser.add_argument("--force", action="store_true", help="Force reindexing of the vector store")
+parser.add_argument("--json-out", type=str, help="Path to write monster sidecar JSON", default=None)
+args = parser.parse_args()
+
+force = args.force
 
 if force:
     kill_other_python_processes()
@@ -70,5 +77,11 @@ with open(LOG_FILE, "w", newline="", encoding="utf-8") as csvfile:
 
 print(f"\nLog saved to: {LOG_FILE}")
 
-response = run_query("goblin boss", type="monster", embed_model=embed_model)
-print(response)
+md, js, _ = run_query("goblin boss", type="monster", embed_model=embed_model)
+print(md)
+if args.json_out and js:
+    out_path = Path(args.json_out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(js, f, indent=2)
+    print(f"Sidecar JSON written to {out_path}")

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -37,7 +37,7 @@ def test_single_token_retry(monkeypatch):
     monkeypatch.setattr(query_router, "maybe_stitch_monster_actions", lambda *a, **k: None)
     monkeypatch.setattr(query_router, "_write_debug_log", lambda *a, **k: None)
 
-    out = query_router.run_query("goblin", type="monster", embed_model=None, alias_map_enabled=False)
-    assert "goblin" in out.lower()
+    md, _, _ = query_router.run_query("goblin", type="monster", embed_model=None, alias_map_enabled=False)
+    assert "goblin" in md.lower()
     assert 50 in calls and 100 in calls
 

--- a/tests/test_monster_json.py
+++ b/tests/test_monster_json.py
@@ -44,3 +44,11 @@ def test_goblin_boss_sidecar(embedder):
     assert "Multiattack" in _names(data["actions"])
     assert any(r["name"] == "Redirect Attack" for r in data["reactions"])
     jsonschema.validate(data, MONSTER_SCHEMA)
+
+
+def test_run_query_returns_tuple(embedder):
+    md, js, prov = run_query(type="monster", query="goblin", embed_model=embedder)
+    assert isinstance(md, str)
+    assert isinstance(js, dict)
+    assert isinstance(prov, list)
+

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -45,17 +45,17 @@ def test_monster_booyahg_whip(embedder):
     assert meta.get("source") == "VGM"
     
 def test_spell_fireball_format(embedder):
-    out = run_query(type="spell", query="fireball", embed_model=embedder)
-    assert "_3rd-level Evocation_" in out
-    assert "**Damage:** 8d6" in out  # allow 8d6 fire or plain 8d6
+    md, _, _ = run_query(type="spell", query="fireball", embed_model=embedder)
+    assert "_3rd-level Evocation_" in md
+    assert "**Damage:** 8d6" in md  # allow 8d6 fire or plain 8d6
 
 def test_monster_booyahg_formatted_output(embedder):
     # Validate MonsterFormatter path via run_query without changing earlier test
-    out = run_query(type="monster", query="booyahg whip", embed_model=embedder)
-    low = out.lower()
+    md, _, _ = run_query(type="monster", query="booyahg whip", embed_model=embedder)
+    low = md.lower()
     assert "armor class" in low
     assert "actions" in low
 
 def test_spell_fireball_provenance(embedder):
-    out = run_query(type="spell", query="fireball", embed_model=embedder)
-    assert "sources considered" in out.lower()
+    md, _, _ = run_query(type="spell", query="fireball", embed_model=embedder)
+    assert "sources considered" in md.lower()


### PR DESCRIPTION
## Summary
- return (markdown, json, provenance) from `run_query`
- add backward-compatible `run_query_legacy`
- optional `--json-out` flag dumps monster sidecar JSON
- update tests for tuple output and add tuple-shape check

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689954d58d388327a0b210478c0c2e81