### PR TITLE
Add interactive play CLI with deterministic combat loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,14 +2,24 @@ import argparse
 import csv
 import json
 import os
+import random
+import shlex
 from datetime import datetime
 from pathlib import Path
 from llama_index.core.settings import Settings
 from llama_index.core.llms.mock import MockLLM
 from indexing import wipe_chroma_store, load_and_index_grouped_by_folder, kill_other_python_processes
-from query_router import run_query
+from query_router import run_query, FALLBACK_MONSTERS
 from engine.session import Session, start_scene, log_step
-from engine.combat import run_round, run_encounter, parse_monster_spec
+from engine.combat import (
+    run_round,
+    run_encounter,
+    parse_monster_spec,
+    choose_target,
+    Combatant,
+)
+from engine.dice import roll
+from engine.checks import attack_roll, damage_roll, saving_throw
 from models import PC, MonsterSidecar
 
 LOG_FILE = f"logs/index_log_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"
@@ -45,8 +55,245 @@ def write_outputs(md: str, js: dict | None, json_out: str | None, md_out: str | 
         print(f"Markdown written to {path}")
 
 
+def _normalize_party(raw: list[dict]) -> list[dict]:
+    """Normalize attack keys in PC JSON."""
+    def _normalize_pc(obj: dict) -> dict:
+        attacks = obj.get("attacks", [])
+        for atk in attacks:
+            if "damage_dice" not in atk and "damage" in atk:
+                atk["damage_dice"] = atk.pop("damage")
+            if "to_hit" not in atk and "attack_bonus" in atk:
+                atk["to_hit"] = atk["attack_bonus"]
+        return obj
+
+    return [_normalize_pc(o) for o in raw]
+
+
+def _lookup_fallback(name: str) -> MonsterSidecar:
+    data = FALLBACK_MONSTERS[name.lower()]
+    return MonsterSidecar(**data)
+
+
+def _serialize_combatant(c: Combatant) -> dict:
+    return {
+        "name": c.name,
+        "ac": c.ac,
+        "hp": c.hp,
+        "side": c.side,
+        "dex_mod": getattr(c, "dex_mod", 0),
+        "attacks": c.attacks,
+        "defeated": c.defeated,
+        "init": getattr(c, "init", 0),
+    }
+
+
+def _deserialize_combatants(data: list[dict]) -> list[Combatant]:
+    combs: list[Combatant] = []
+    for cd in data:
+        c = Combatant(cd["name"], cd["ac"], cd["hp"], cd["attacks"], cd["side"], cd.get("dex_mod", 0))
+        c.defeated = cd.get("defeated", False)
+        c.init = cd.get("init", 0)
+        combs.append(c)
+    combs.sort(key=lambda c: c.init, reverse=True)
+    return combs
+
+
+def _print_status(round_num: int, combatants: list[Combatant]) -> None:
+    print(f"Round {round_num}")
+    order = ", ".join(c.name for c in combatants)
+    print(f"Initiative: {order}")
+    for c in combatants:
+        hp = "DEFEATED" if c.defeated else f"{c.hp} HP"
+        print(f"{c.name}: {hp}, AC {c.ac}")
+
+
+def _check_victory(combatants: list[Combatant]) -> str | None:
+    party_alive = any(c.side == "party" and not c.defeated for c in combatants)
+    monsters_alive = any(c.side == "monsters" and not c.defeated for c in combatants)
+    if not party_alive:
+        return "monsters"
+    if not monsters_alive:
+        return "party"
+    return None
+
+
+def _save_game(path: str, seed: int | None, round_num: int, turn: int, combatants: list[Combatant]) -> None:
+    sess = Session(scene="play", seed=seed, steps=[{
+        "round": round_num,
+        "turn": turn,
+        "combatants": [_serialize_combatant(c) for c in combatants],
+    }])
+    sess.save(path)
+    print(f"Saved to {path}")
+
+
+def _load_game(path: str):
+    sess = Session.load(path)
+    if sess.steps:
+        data = sess.steps[0]
+        round_num = data.get("round", 1)
+        turn = data.get("turn", 0)
+        combatants = _deserialize_combatants(data.get("combatants", []))
+    else:
+        round_num = 1
+        turn = 0
+        combatants = []
+    return sess.seed, round_num, turn, combatants
+
+
+def play_cli(pcs: list[PC], monsters: list[MonsterSidecar], seed: int | None = None, max_rounds: int = 20) -> None:
+    rng = random.Random(seed)
+    if seed is not None:
+        print(f"Using seed: {seed}")
+
+    combatants: list[Combatant] = []
+    combatants.extend([Combatant(p.name, p.ac, p.hp, [a.dict() for a in p.attacks], "party", 0) for p in pcs])
+    for m in monsters:
+        c = Combatant(m.name, int(m.ac.split()[0]), 0, [], "monsters", (m.dex - 10) // 2)
+        hp_str = m.hp
+        if "(" in hp_str and ")" in hp_str:
+            expr = hp_str.split("(")[1].split(")")[0]
+            hp_seed = rng.randint(0, 10_000_000)
+            c.hp = roll(expr, seed=hp_seed)["total"]
+        else:
+            c.hp = int(hp_str.split()[0])
+        c.attacks = [
+            {"name": a.name, "to_hit": a.attack_bonus, "damage_dice": a.damage_dice, "type": a.type}
+            for a in m.actions_struct
+        ]
+        combatants.append(c)
+
+    for c in combatants:
+        init_seed = rng.randint(0, 10_000_000)
+        c.init = roll(f"1d20+{getattr(c, 'dex_mod', 0)}", seed=init_seed)["total"]
+    combatants.sort(key=lambda c: c.init, reverse=True)
+
+    round_num = 1
+    turn = 0
+    while round_num <= max_rounds:
+        winner = _check_victory(combatants)
+        if winner:
+            print(f"{winner.capitalize()} wins!")
+            return
+        actor = combatants[turn]
+        if actor.defeated:
+            turn = (turn + 1) % len(combatants)
+            if turn == 0:
+                round_num += 1
+            continue
+        if actor.side == "party":
+            while True:
+                try:
+                    cmd = input("> ").strip()
+                except EOFError:
+                    return
+                if not cmd:
+                    continue
+                parts = shlex.split(cmd)
+                if parts[0] == "status":
+                    _print_status(round_num, combatants)
+                elif parts[0] == "help":
+                    print("Commands: status, attack <pc> <target> \"<attack>\" [adv|dis], cast <pc> \"<spell>\" [all|<target>], end, save <path>, load <path>, quit")
+                elif parts[0] == "quit":
+                    return
+                elif parts[0] == "save" and len(parts) == 2:
+                    _save_game(parts[1], seed, round_num, turn, combatants)
+                elif parts[0] == "load" and len(parts) == 2:
+                    seed, round_num, turn, combatants = _load_game(parts[1])
+                elif parts[0] == "attack" and len(parts) >= 4:
+                    name, target_name, atk_name = parts[1], parts[2], parts[3]
+                    adv = len(parts) > 4 and parts[4] == "adv"
+                    dis = len(parts) > 4 and parts[4] == "dis"
+                    if name != actor.name:
+                        print(f"It's {actor.name}'s turn")
+                        continue
+                    target = next((c for c in combatants if c.name == target_name and not c.defeated), None)
+                    if not target:
+                        print("Unknown target")
+                        continue
+                    attack = next((a for a in actor.attacks if a["name"] == atk_name), None)
+                    if not attack:
+                        print("Unknown attack")
+                        continue
+                    hit_seed = rng.randint(0, 10_000_000)
+                    if adv or dis:
+                        atk_res = roll(f"1d20+{attack['to_hit']}", seed=hit_seed, adv=adv, disadv=dis)
+                        hit = atk_res["total"] >= target.ac
+                    else:
+                        atk_res = attack_roll(attack["to_hit"], target.ac, hit_seed)
+                        hit = atk_res["hit"]
+                    if hit:
+                        dmg_seed = rng.randint(0, 10_000_000)
+                        dmg = damage_roll(attack["damage_dice"], dmg_seed)
+                        target.hp -= dmg["total"]
+                        print(f"{actor.name} hits {target.name} for {dmg['total']}")
+                        if target.hp <= 0:
+                            target.defeated = True
+                            print(f"{target.name} is defeated")
+                    else:
+                        print(f"{actor.name} misses {target.name}")
+                elif parts[0] == "cast" and len(parts) >= 3:
+                    name, spell_name = parts[1], parts[2]
+                    target_spec = parts[3] if len(parts) > 3 else "all"
+                    if name != actor.name:
+                        print(f"It's {actor.name}'s turn")
+                        continue
+                    attack = next((a for a in actor.attacks if a["name"] == spell_name), None)
+                    if not attack:
+                        print("Unknown spell")
+                        continue
+                    enemies = [c for c in combatants if c.side != actor.side and not c.defeated]
+                    if target_spec != "all":
+                        enemies = [c for c in enemies if c.name == target_spec]
+                    if not enemies:
+                        print("No targets")
+                        continue
+                    dmg_seed = rng.randint(0, 10_000_000)
+                    dmg_total = damage_roll(attack["damage_dice"], dmg_seed)["total"]
+                    ability = attack.get("save_ability", "dex")
+                    for tgt in enemies:
+                        save_seed = rng.randint(0, 10_000_000)
+                        mod = getattr(tgt, f"{ability}_mod", getattr(tgt, "dex_mod", 0))
+                        save = saving_throw(attack.get("save_dc", 0), mod, seed=save_seed)
+                        print(f"{tgt.name} Dex save {'succeeds' if save['success'] else 'fails'}")
+                        taken = dmg_total if not save["success"] else dmg_total // 2
+                        tgt.hp -= taken
+                        print(f"{actor.name}'s {attack['name']} hits {tgt.name} for {taken}")
+                        if tgt.hp <= 0:
+                            tgt.defeated = True
+                            print(f"{tgt.name} is defeated")
+                elif parts[0] == "end":
+                    break
+                else:
+                    print("Unknown command")
+        else:
+            enemies = [c for c in combatants if c.side != actor.side and not c.defeated]
+            if enemies:
+                attack = actor.attacks[0]
+                target_seed = rng.randint(0, 10_000_000)
+                target = choose_target(actor, enemies, seed=target_seed)
+                hit_seed = rng.randint(0, 10_000_000)
+                atk = attack_roll(attack["to_hit"], target.ac, hit_seed)
+                if atk["hit"]:
+                    dmg_seed = rng.randint(0, 10_000_000)
+                    dmg = damage_roll(attack["damage_dice"], dmg_seed)
+                    target.hp -= dmg["total"]
+                    print(f"{actor.name} hits {target.name} for {dmg['total']}")
+                    if target.hp <= 0:
+                        target.defeated = True
+                        print(f"{target.name} is defeated")
+                else:
+                    print(f"{actor.name} misses {target.name}")
+        turn = (turn + 1) % len(combatants)
+        if turn == 0:
+            round_num += 1
+    print("Max rounds reached")
+
+
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--play", action="store_true", help="Interactive play mode")
+    parser.add_argument("--max-rounds", type=int, default=20, help="Max rounds for --play")
     parser.add_argument("--force", action="store_true", help="Force reindexing of the vector store")
     parser.add_argument("--json-out", nargs="?", const="logs/last_sidecar.json", help="Write sidecar JSON to path", default=None)
     parser.add_argument("--md-out", type=str, help="Write markdown output to path", default=None)
@@ -60,6 +307,20 @@ def main():
     parser.add_argument("--rounds", type=int, help="Max combat rounds", default=10)
     parser.add_argument("--summary-out", type=str, help="Write encounter summary JSON", default=None)
     args = parser.parse_args()
+
+    if args.play:
+        if not args.pc or not args.encounter:
+            raise SystemExit("--pc and --encounter required for --play")
+        raw = json.loads(Path(args.pc).read_text())
+        if isinstance(raw, dict) and "party" in raw:
+            raw = raw["party"]
+        if not isinstance(raw, list):
+            raise ValueError("PC file must be a list or contain 'party'")
+        raw = _normalize_party(raw)
+        pcs = [PC(**o) for o in raw]
+        monsters = parse_monster_spec(args.encounter, _lookup_fallback)
+        play_cli(pcs, monsters, seed=args.seed, max_rounds=args.max_rounds)
+        return
 
     embed_model, msg = choose_embedding(args.embeddings)
     print(msg)

--- a/tests/test_play_cli.py
+++ b/tests/test_play_cli.py
@@ -1,0 +1,64 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def _write_pc(tmp_path: Path, pcs: list[dict]) -> Path:
+    path = tmp_path / "pc.json"
+    path.write_text(json.dumps({"party": pcs}))
+    return path
+
+
+def run_play(cmds: str, pc_file: Path, encounter: str, seed: int | None = None) -> subprocess.CompletedProcess:
+    args = ["python", "main.py", "--play", "--pc", str(pc_file), "--encounter", encounter]
+    if seed is not None:
+        args += ["--seed", str(seed)]
+    proc = subprocess.run(args, input=cmds, text=True, capture_output=True, timeout=20)
+    return proc
+
+
+def test_basic_attack_flow(tmp_path):
+    pcs = [
+        {"name": "Malrick", "ac": 15, "hp": 20, "attacks": [{"name": "Shortsword", "to_hit": 5, "damage_dice": "1d6+3", "type": "melee"}]}
+    ]
+    pc_file = _write_pc(tmp_path, pcs)
+    script = "status\nattack Malrick Goblin \"Shortsword\"\nstatus\nend\n"
+    res = run_play(script, pc_file, "goblin", seed=1)
+    out = res.stdout
+    assert "Malrick hits Goblin" in out
+    lines = [l for l in out.splitlines() if l.startswith("Goblin:")]
+    assert len(lines) == 2
+    def _hp(line: str) -> int:
+        parts = line.split()
+        return 0 if parts[1] == "DEFEATED," else int(parts[1])
+    hp_vals = [_hp(l) for l in lines]
+    assert hp_vals[1] < hp_vals[0]
+
+
+def test_cast_fireball_flow(tmp_path):
+    pcs = [
+        {"name": "Brynn", "ac": 14, "hp": 16, "attacks": [
+            {"name": "Fireball", "damage_dice": "8d6", "type": "spell", "save_dc": 14, "save_ability": "dex"}
+        ]}
+    ]
+    pc_file = _write_pc(tmp_path, pcs)
+    script = "cast Brynn \"Fireball\" all\nend\n"
+    res = run_play(script, pc_file, "goblin x2", seed=2)
+    out = res.stdout
+    assert out.count("Dex save") == 2
+    dmg = [int(d) for d in __import__("re").findall(r"Fireball hits Goblin for (\d+)", out)]
+    assert len(dmg) == 2
+    dmg.sort()
+    assert dmg[1] == dmg[0] * 2 or dmg[0] == dmg[1]
+
+
+def test_seed_determinism(tmp_path):
+    pcs = [
+        {"name": "Malrick", "ac": 15, "hp": 20, "attacks": [{"name": "Shortsword", "to_hit": 5, "damage_dice": "1d6+3", "type": "melee"}]}
+    ]
+    pc_file = _write_pc(tmp_path, pcs)
+    script = "status\nattack Malrick Goblin \"Shortsword\"\nend\n"
+    res1 = run_play(script, pc_file, "goblin", seed=42)
+    res2 = run_play(script, pc_file, "goblin", seed=42)
+    assert res1.stdout == res2.stdout
+


### PR DESCRIPTION
## Summary
- add `--play` interactive mode with commands for status, attack, cast, save/load, and more
- support deterministic seeding and basic monster AI using existing combat helpers
- cover play mode with tests for attacks, spell casting, and seeded determinism

## Testing
- `pytest tests/test_play_cli.py -q`
- `pytest tests/test_run_encounter.py::test_encounter_deterministic_and_max_rounds -q`


------
https://chatgpt.com/codex/tasks/task_e_689a29f0ba2483278d15f5b19eb3ace1