### PR TITLE
Ensure play CLI reads scripted input

### DIFF
--- a/main.py
+++ b/main.py
@@ -178,8 +178,9 @@ def play_cli(
 
     cmd_iter: Iterator[str] | None = None
     if not sys.stdin.isatty():
-        cmds = [ln.strip() for ln in sys.stdin.read().splitlines() if ln.strip()]
-        cmd_iter = iter(cmds)
+        data = sys.stdin.read()
+        if data:
+            cmd_iter = iter(ln.strip() for ln in data.splitlines() if ln.strip())
 
     round_num = 1
     turn = 0


### PR DESCRIPTION
## Summary
- Improve play_cli to consume non-interactive stdin only when data is present

## Testing
- `pytest -q`
- `pytest tests/test_play_cli.py::test_basic_attack_flow tests/test_play_cli.py::test_cast_fireball_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_689a3b918c9c8327a8aad6df08e4c5c0