### PR TITLE
Improve play CLI UX and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
    ```bash
    python main.py --scene "market brawl" --json-out logs/side.json --md-out logs/side.md
    ```
-   This prints a formatted entry and writes the markdown and sidecar JSON to disk.
+   This prints a formatted entry and writes both markdown and JSON sidecars.
 4. **Python API**
    ```python
    from grimbrain.retrieval.query_router import run_query
@@ -27,11 +27,12 @@
    ```
    The ``run_query`` function always returns a tuple ``(markdown, json, provenance)``.
 
-5. **Combat round**
+5. **Play mode**
    ```bash
-   python main.py --pc tests/pc.json --encounter "goblin" --rounds 1
+   python main.py --play --pc tests/pc.json --encounter "goblin" --seed 1 --autosave
    ```
-   This loads PCs from ``pc.json``, runs a single combat round against a goblin and prints the log.
+   Loads PCs from ``pc.json`` and drops you into an interactive fight. Use
+   shorthand commands like `a` for attack, `c` for cast, `s` for status and `q` to quit.
 
    Example ``pc.json``:
    ```json
@@ -60,3 +61,5 @@ Use `--embeddings` to select embedding mode:
 
 - `--json-out` optionally takes a path (defaults to `logs/last_sidecar.json`)
 - `--md-out` writes the markdown output
+- `--play` enables interactive combat; combine with `--seed` for determinism
+- `--autosave` appends turn summaries to paired markdown/JSON logs

--- a/tests/golden/goblin.json
+++ b/tests/golden/goblin.json
@@ -1,0 +1,55 @@
+{
+  "name": "Goblin",
+  "source": "MM",
+  "ac": "15 (leather armor, shield)",
+  "hp": "7 (2d6)",
+  "speed": "30 ft.",
+  "str": 8,
+  "dex": 14,
+  "con": 10,
+  "int": 10,
+  "wis": 8,
+  "cha": 8,
+  "traits": [
+    {
+      "name": "Nimble Escape",
+      "text": "The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+    }
+  ],
+  "actions": [
+    {
+      "name": "Scimitar",
+      "text": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage."
+    },
+    {
+      "name": "Shortbow",
+      "text": "Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+    }
+  ],
+  "actions_struct": [
+    {
+      "name": "Scimitar",
+      "attack_bonus": 4,
+      "type": "melee",
+      "reach_or_range": "reach 5 ft.",
+      "target": "one target",
+      "hit_text": "5 (1d6 + 2) slashing damage.",
+      "damage_dice": "1d6 + 2",
+      "damage_type": "slashing"
+    },
+    {
+      "name": "Shortbow",
+      "attack_bonus": 4,
+      "type": "ranged",
+      "reach_or_range": "range 80/320 ft.",
+      "target": "one target",
+      "hit_text": "5 (1d6 + 2) piercing damage.",
+      "damage_dice": "1d6 + 2",
+      "damage_type": "piercing"
+    }
+  ],
+  "reactions": [],
+  "provenance": [
+    "MM \u00b7 Goblin"
+  ]
+}

--- a/tests/golden/goblin.md
+++ b/tests/golden/goblin.md
@@ -1,0 +1,13 @@
+### Goblin — MM
+
+**Armor Class**: 15 (leather armor, shield)
+**Hit Points**: 7 (2d6)
+**Speed**: 30 ft.
+**STR** 8  **DEX** 14  **CON** 10  **INT** 10  **WIS** 8  **CHA** 8
+
+**Traits**
+- **Nimble Escape.** The goblin can take the Disengage or Hide action as a bonus action on each of its turns.
+
+**Actions**
+- **Scimitar.** Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage.
+- **Shortbow.** Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.

--- a/tests/test_golden_outputs.py
+++ b/tests/test_golden_outputs.py
@@ -1,0 +1,16 @@
+import json
+import os
+from pathlib import Path
+from grimbrain.retrieval.query_router import run_query
+
+
+def test_goblin_golden(embedder):
+    md, js, _ = run_query(type="monster", query="goblin", embed_model=embedder)
+    base = Path(__file__).parent / "golden" / "goblin"
+    md_path = base.with_suffix(".md")
+    json_path = base.with_suffix(".json")
+    if os.getenv("UPDATE_GOLDENS"):
+        md_path.write_text(md)
+        json_path.write_text(json.dumps(js, indent=2))
+    assert md_path.read_text() == md
+    assert json.loads(json_path.read_text()) == js

--- a/tests/test_play_cli.py
+++ b/tests/test_play_cli.py
@@ -40,7 +40,7 @@ def test_basic_attack_flow(tmp_path):
         {"name": "Malrick", "ac": 15, "hp": 20, "attacks": [{"name": "Shortsword", "to_hit": 5, "damage_dice": "1d6+3", "type": "melee"}]}
     ]
     pc_file = _write_pc(tmp_path, pcs)
-    script = "status\nattack Malrick Goblin \"Shortsword\"\nstatus\nend\n"
+    script = "s\na Goblin \"Shortsword\"\ns\nend\n"
     res = run_play(script, pc_file, "goblin", seed=1)
     out = res.stdout
     assert "Malrick hits Goblin" in out
@@ -60,7 +60,7 @@ def test_cast_fireball_flow(tmp_path):
         ]}
     ]
     pc_file = _write_pc(tmp_path, pcs)
-    script = "cast Brynn \"Fireball\" all\nend\n"
+    script = "c \"Fireball\" all\nend\n"
     res = run_play(script, pc_file, "goblin x2", seed=2)
     out = res.stdout
     assert out.count("Dex save") == 2
@@ -75,8 +75,20 @@ def test_seed_determinism(tmp_path):
         {"name": "Malrick", "ac": 15, "hp": 20, "attacks": [{"name": "Shortsword", "to_hit": 5, "damage_dice": "1d6+3", "type": "melee"}]}
     ]
     pc_file = _write_pc(tmp_path, pcs)
-    script = "status\nattack Malrick Goblin \"Shortsword\"\nend\n"
+    script = "s\na Goblin \"Shortsword\"\nend\n"
     res1 = run_play(script, pc_file, "goblin", seed=42)
     res2 = run_play(script, pc_file, "goblin", seed=42)
     assert res1.stdout == res2.stdout
+
+
+def test_typo_and_actions(tmp_path):
+    pcs = [
+        {"name": "Malrick", "ac": 15, "hp": 20, "attacks": [{"name": "Shortsword", "to_hit": 5, "damage_dice": "1d6+3", "type": "melee"}]}
+    ]
+    pc_file = _write_pc(tmp_path, pcs)
+    script = "attak Goblin \"Shortsword\"\nactions\nq\n"
+    res = run_play(script, pc_file, "goblin", seed=1)
+    out = res.stdout
+    assert "Malrick hits Goblin" in out
+    assert "Shortsword" in out
 


### PR DESCRIPTION
## Summary
- Add command aliases, typo tolerance and default actor handling to the play CLI
- Print turn summaries with optional autosave and post-battle loot/XP
- Lock golden query outputs and refresh README quickstart

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a5498dc248327a4721ee81357e8cd