### PR TITLE
Add character sheet and campaign management support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@
    Hero misses Goblin
    ```
 
+   Play mode also accepts a single character sheet JSON/YAML describing a PC. Missing
+   attack bonuses and spell save DCs are derived from ability scores and proficiency.
+   For longer running games, pass ``--campaign campaign.yaml`` to track quests and notes
+   and to save session logs under ``campaigns/<name>/sessions``.
+
 ### Embeddings flag
 
 Use `--embeddings` to select embedding mode:

--- a/grimbrain/campaign.py
+++ b/grimbrain/campaign.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import json
+import yaml
+from pydantic import BaseModel, Field
+
+from .models import PC
+from .models_character import load_pc_sheet
+
+
+class Quest(BaseModel):
+    id: str
+    title: str
+    status: str = "active"
+    notes: List[str] = Field(default_factory=list)
+
+
+class Campaign(BaseModel):
+    name: str
+    party_files: List[str]
+    locations: List[Dict[str, Any]] = Field(default_factory=list)
+    factions: List[Dict[str, Any]] = Field(default_factory=list)
+    quests: List[Quest] = Field(default_factory=list)
+    notes: List[str] = Field(default_factory=list)
+    seed: int | None = None
+    last_session: str | None = None
+
+    _path: Path | None = None
+
+    def save(self, path: str | Path | None = None) -> Path:
+        p = Path(path) if path else self._path
+        if p is None:
+            raise ValueError("Campaign path unknown")
+        data = self.model_dump(exclude={"_path"}) if hasattr(self, "model_dump") else self.dict(exclude={"_path"})
+        p.write_text(yaml.safe_dump(data, sort_keys=False))
+        self._path = p
+        return p
+
+
+def load_campaign(path: str | Path) -> Campaign:
+    p = Path(path)
+    data = yaml.safe_load(p.read_text())
+    camp = Campaign(**data)
+    camp._path = p
+    return camp
+
+
+def load_party_file(path: Path) -> List[PC]:
+    text = path.read_text()
+    try:
+        data = json.loads(text)
+    except Exception:
+        data = yaml.safe_load(text)
+    if isinstance(data, list):
+        raw = _normalize_party(data)
+        return [PC(**obj) for obj in raw]
+    if isinstance(data, dict) and "party" in data:
+        raw = _normalize_party(data["party"])
+        return [PC(**obj) for obj in raw]
+    if isinstance(data, dict) and "class" in data and "abilities" in data:
+        sheet = load_pc_sheet(path)
+        return [sheet.to_pc()]
+    raw = _normalize_party(data if isinstance(data, list) else [data])
+    return [PC(**obj) for obj in raw]
+
+
+def _normalize_party(raw: list[dict]) -> list[dict]:
+    def _normalize_pc(obj: dict) -> dict:
+        attacks = obj.get("attacks", [])
+        for atk in attacks:
+            if "damage_dice" not in atk and "damage" in atk:
+                atk["damage_dice"] = atk.pop("damage")
+            if "to_hit" not in atk and "attack_bonus" in atk:
+                atk["to_hit"] = atk["attack_bonus"]
+        return obj
+
+    return [_normalize_pc(o) for o in raw]

--- a/grimbrain/models_character.py
+++ b/grimbrain/models_character.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import json
+import yaml
+from pydantic import BaseModel, Field
+
+from .models import PC, Attack
+
+
+class PCSheetAttack(BaseModel):
+    name: str
+    damage_dice: str
+    type: str
+    ability: str
+    proficient: bool = True
+    to_hit: int | None = None
+    save_dc: int | None = None
+    save_ability: str | None = None
+
+
+class PCSheet(BaseModel):
+    name: str
+    class_: str = Field(alias="class")
+    level: int
+    abilities: Dict[str, int]
+    ac: int = 10
+    hp: int = 1
+    prof_bonus: int | None = None
+    saves: Dict[str, int] = Field(default_factory=dict)
+    skills: Dict[str, int] = Field(default_factory=dict)
+    attacks: List[PCSheetAttack] = Field(default_factory=list)
+    prepared_spells: List[Dict[str, Any]] = Field(default_factory=list)
+    resources: Dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def pb(self) -> int:
+        return self.prof_bonus if self.prof_bonus is not None else 2 + (self.level - 1) // 4
+
+    def to_pc(self) -> PC:
+        atks: List[Attack] = []
+        for atk in self.attacks:
+            to_hit = atk.to_hit if atk.to_hit is not None else attack_to_hit(self, atk)
+            save_dc = atk.save_dc
+            if save_dc is None and atk.save_ability:
+                save_dc = spell_save_dc(self, atk.save_ability)
+            atks.append(Attack(name=atk.name, damage_dice=atk.damage_dice, type=atk.type, to_hit=to_hit, save_dc=save_dc, save_ability=atk.save_ability))
+        return PC(name=self.name, ac=self.ac, hp=self.hp, attacks=atks)
+
+
+def ability_mod(score: int) -> int:
+    return (score - 10) // 2
+
+
+def spell_save_dc(pc: PCSheet, ability: str = "int") -> int:
+    return 8 + ability_mod(pc.abilities.get(ability, 10)) + pc.pb
+
+
+def attack_to_hit(pc: PCSheet, attack: PCSheetAttack) -> int:
+    mod = ability_mod(pc.abilities.get(attack.ability, 10))
+    if attack.proficient:
+        mod += pc.pb
+    return mod
+
+
+def load_pc_sheet(path: str | Path) -> PCSheet:
+    path = Path(path)
+    text = path.read_text()
+    data: Dict[str, Any]
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        data = yaml.safe_load(text)
+    return PCSheet(**data)

--- a/tests/test_campaign_cli.py
+++ b/tests/test_campaign_cli.py
@@ -1,0 +1,82 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+import json
+
+from grimbrain.campaign import load_campaign
+
+
+def _setup_campaign(tmp_path: Path) -> Path:
+    fighter = {
+        "name": "Roth",
+        "ac": 15,
+        "hp": 20,
+        "attacks": [{"name": "Sword", "to_hit": 5, "damage_dice": "1d8+3", "type": "melee"}],
+    }
+    wizard = {
+        "name": "Brynn",
+        "class": "Wizard",
+        "level": 3,
+        "abilities": {"str": 8, "dex": 14, "con": 12, "int": 16, "wis": 12, "cha": 10},
+        "ac": 14,
+        "hp": 16,
+        "attacks": [
+            {"name": "Quarterstaff", "proficient": True, "ability": "str", "damage_dice": "1d6+2", "type": "melee"}
+        ],
+    }
+    (tmp_path / "pc_fighter.json").write_text(json.dumps(fighter))
+    (tmp_path / "pc_wizard.json").write_text(json.dumps(wizard))
+    campaign = {
+        "name": "Greenvale Troubles",
+        "party_files": ["pc_fighter.json", "pc_wizard.json"],
+        "quests": [{"id": "q1", "title": "Bandits on the road", "status": "active"}],
+        "notes": [],
+        "seed": 42,
+    }
+    path = tmp_path / "campaign.yaml"
+    path.write_text(yaml.safe_dump(campaign))
+    return path
+
+
+def run_play(cmds: str, campaign_file: Path) -> subprocess.CompletedProcess:
+    main_path = Path(__file__).resolve().parent.parent / "main.py"
+    args = [
+        sys.executable,
+        str(main_path),
+        "--play",
+        "--campaign",
+        str(campaign_file),
+        "--encounter",
+        "goblin",
+        "--max-rounds",
+        "1",
+        "--seed",
+        "1",
+    ]
+    return subprocess.run(
+        args,
+        input=cmds,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        cwd=str(campaign_file.parent),
+    )
+
+
+def test_campaign_commands_and_logging(tmp_path):
+    camp_path = _setup_campaign(tmp_path)
+    script = (
+        "note \"Scary woods\"\n" "quest add \"Find relic\"\n" "quest done q1\n" "save\n" "end\n"
+    )
+    res = run_play(script, camp_path)
+    assert res.returncode == 0
+    camp = load_campaign(camp_path)
+    assert any(q.id == "q2" and q.title == "Find relic" for q in camp.quests)
+    q1 = next(q for q in camp.quests if q.id == "q1")
+    assert q1.status == "done"
+    assert "Scary woods" in camp.notes
+    sess_dir = tmp_path / "campaigns" / "Greenvale Troubles" / "sessions"
+    assert list(sess_dir.glob("*.json"))
+    assert camp.last_session and Path(camp.last_session).exists()

--- a/tests/test_character_sheet.py
+++ b/tests/test_character_sheet.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from grimbrain.models_character import (
+    PCSheet,
+    ability_mod,
+    attack_to_hit,
+    load_pc_sheet,
+    spell_save_dc,
+)
+
+
+def test_load_sheet_and_helpers(tmp_path):
+    data = {
+        "name": "Brynn",
+        "class": "Wizard",
+        "level": 3,
+        "abilities": {"str": 8, "dex": 14, "con": 12, "int": 16, "wis": 12, "cha": 10},
+        "ac": 14,
+        "hp": 16,
+        "attacks": [
+            {
+                "name": "Quarterstaff",
+                "proficient": True,
+                "ability": "str",
+                "damage_dice": "1d6+2",
+                "type": "melee",
+            }
+        ],
+        "prepared_spells": [{"name": "Fireball", "level": 3}],
+        "resources": {"hit_dice": "3d6"},
+    }
+    path = tmp_path / "pc_wizard.json"
+    path.write_text(json.dumps(data))
+    sheet = load_pc_sheet(path)
+    assert ability_mod(sheet.abilities["int"]) == 3
+    assert sheet.pb == 2
+    assert spell_save_dc(sheet) == 13
+    atk = sheet.attacks[0]
+    assert attack_to_hit(sheet, atk) == 1
+    pc = sheet.to_pc()
+    assert pc.attacks[0].to_hit == 1


### PR DESCRIPTION
## Summary
- support loading detailed PC sheets with derived ability modifiers and attack bonuses
- introduce campaign YAML model with quests, notes and session logging
- extend play CLI with `--campaign` option and quest/note/save commands

## Testing
- `pytest tests/test_character_sheet.py tests/test_campaign_cli.py::test_campaign_commands_and_logging -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a951817648327b66d5a92c718a324