### PR TITLE
Skip retrieval when resuming session

### DIFF
--- a/main.py
+++ b/main.py
@@ -529,6 +529,11 @@ def main():
         )
         return
 
+    if args.resume and not any([args.scene, args.pc, args.encounter, args.campaign, args.play]):
+        session = Session.load(args.resume)
+        print(f"Resumed scene '{session.scene}' with {len(session.steps)} steps")
+        return
+
     from llama_index.core.settings import Settings
     from llama_index.core.llms.mock import MockLLM
     from grimbrain.retrieval.indexing import (

--- a/tests/test_cli_resume_offline.py
+++ b/tests/test_cli_resume_offline.py
@@ -1,0 +1,21 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from grimbrain.engine.session import Session
+
+def test_cli_resume_offline(tmp_path):
+    session = Session(scene="play", seed=1, steps=[{"round": 1}])
+    save_path = tmp_path / "save.json"
+    session.save(save_path)
+
+    main_path = Path(__file__).resolve().parent.parent / "main.py"
+    proc = subprocess.run(
+        [sys.executable, str(main_path), "--resume", str(save_path)],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert proc.returncode == 0
+    assert "Resumed scene 'play' with 1 steps" in proc.stdout


### PR DESCRIPTION
## Summary
- Avoid running indexing/embedding when CLI is invoked with only `--resume`
- Add regression test to ensure resuming works offline without extra dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b51786298832799b151c72e0048db