### PR TITLE
Handle legacy choice keys in campaign loader

### DIFF
--- a/grimbrain/engine/campaign.py
+++ b/grimbrain/engine/campaign.py
@@ -58,7 +58,14 @@ def load_campaign(path: str | Path) -> Campaign:
     scenes: Dict[str, Scene] = {}
     raw_scenes = data.get("scenes", {})
     for sid, sdata in raw_scenes.items():
-        choices = [Choice(**c) for c in sdata.get("choices", [])]
+        choices: List[Choice] = []
+        for c in sdata.get("choices", []):
+            c_map = dict(c)
+            if "label" in c_map and "text" not in c_map:
+                c_map["text"] = c_map.pop("label")
+            if "goto" in c_map and "next" not in c_map:
+                c_map["next"] = c_map.pop("goto")
+            choices.append(Choice(**c_map))
         check = Check(**sdata["check"]) if "check" in sdata else None
         scenes[sid] = Scene(
             id=sid,
@@ -71,7 +78,7 @@ def load_campaign(path: str | Path) -> Campaign:
         )
     start = data.get("start") or next(iter(scenes))
     camp = Campaign(
-        name=data.get("name", "Unnamed"),
+        name=data.get("name") or data.get("title", "Unnamed"),
         party_files=data.get("party_files", []),
         scenes=scenes,
         start=start,


### PR DESCRIPTION
## Summary
- allow campaign choices using `label`/`goto` to load
- support `title` as alias for `name` in campaign metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b66a4afe88327a98b21ade9d56e50