### PR TITLE
feat: add campaign autostart and pc wizard

### DIFF
--- a/grimbrain/engine/campaign.py
+++ b/grimbrain/engine/campaign.py
@@ -94,10 +94,15 @@ def load_party(camp: Campaign, base: Path) -> List[PC]:
     return pcs
 
 
-def run_encounter(pcs: List[PC], enemy_name: str, seed: int | None = None) -> Dict[str, object]:
+def run_encounter(
+    pcs: List[PC],
+    enemy_name: str,
+    seed: int | None = None,
+    max_rounds: int = 10,
+) -> Dict[str, object]:
     data = FALLBACK_MONSTERS[enemy_name.lower()]
     mon = MonsterSidecar(**data)
-    res = _run_encounter(pcs, [mon], seed=seed)
+    res = _run_encounter(pcs, [mon], seed=seed, max_rounds=max_rounds)
     outcome = "victory" if res["winner"] == "party" else "defeat"
     hp = {c["name"]: c["hp"] for c in res["state"]["party"]}
     summary = f"{outcome} in {res['rounds']} rounds"

--- a/grimbrain/engine/combat.py
+++ b/grimbrain/engine/combat.py
@@ -134,7 +134,10 @@ def run_encounter(
     log: List[str] = []
     rounds = 0
 
-    while rounds < max_rounds:
+    party_alive = any(c.side == "party" and not c.defeated for c in combatants)
+    monsters_alive = any(c.side == "monsters" and not c.defeated for c in combatants)
+
+    while rounds < max_rounds and party_alive and monsters_alive:
         rounds += 1
         for actor in combatants:
             if actor.defeated:

--- a/grimbrain/pc_wizard.py
+++ b/grimbrain/pc_wizard.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+from .models import PC, dump_model
+
+PRESETS = {
+    "fighter": [
+        {
+            "name": "Malrick",
+            "ac": 16,
+            "hp": 20,
+            "attacks": [
+                {"name": "Longsword", "to_hit": 5, "damage_dice": "1d8+3", "type": "melee"}
+            ],
+        },
+        {
+            "name": "Brynn",
+            "ac": 14,
+            "hp": 16,
+            "attacks": [
+                {"name": "Shortsword", "to_hit": 4, "damage_dice": "1d6+2", "type": "melee"}
+            ],
+        },
+    ],
+    "rogue": [
+        {
+            "name": "Brynn",
+            "ac": 14,
+            "hp": 16,
+            "attacks": [
+                {"name": "Dagger", "to_hit": 5, "damage_dice": "1d4+3", "type": "melee"}
+            ],
+        }
+    ],
+    "wizard": [
+        {
+            "name": "Elora",
+            "ac": 12,
+            "hp": 12,
+            "attacks": [
+                {"name": "Fire Bolt", "to_hit": 5, "damage_dice": "1d10", "type": "ranged"}
+            ],
+        }
+    ],
+}
+
+
+def _interactive_party() -> List[dict] | None:
+    print("PC Wizard: create up to 2 PCs. Leave name blank to finish.")
+    party: List[dict] = []
+    for _ in range(2):
+        name = input("Name: ").strip()
+        if not name:
+            break
+        ac = int(input("AC: ").strip())
+        hp = int(input("HP: ").strip())
+        atk_name = input("Attack name: ").strip()
+        to_hit = int(input("To-hit bonus: ").strip())
+        dmg = input("Damage dice (e.g., 1d6+3): ").strip()
+        atk_type = input("Attack type (melee|ranged): ").strip() or "melee"
+        party.append(
+            {
+                "name": name,
+                "ac": ac,
+                "hp": hp,
+                "attacks": [
+                    {
+                        "name": atk_name,
+                        "to_hit": to_hit,
+                        "damage_dice": dmg,
+                        "type": atk_type,
+                    }
+                ],
+            }
+        )
+    return party or None
+
+
+def main(out: str | None = None, preset: str | None = None) -> Path | None:
+    if preset:
+        party = PRESETS.get(preset)
+    else:
+        party = _interactive_party()
+    if not party:
+        print("No characters created.")
+        return None
+
+    pcs = [PC(**pc) for pc in party]
+    data = {"party": [dump_model(pc) for pc in pcs]}
+    path = Path(out or "pc.json")
+    path.write_text(json.dumps(data, indent=2))
+    print(f"Wrote party to {path} ({len(pcs)} characters).")
+    return path

--- a/tests/test_pc_wizard.py
+++ b/tests/test_pc_wizard.py
@@ -1,0 +1,25 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from grimbrain.campaign import load_party_file
+
+
+def test_pc_wizard_preset(tmp_path):
+    out = tmp_path / "party.json"
+    main_path = Path(__file__).resolve().parent.parent / "main.py"
+    args = [
+        sys.executable,
+        str(main_path),
+        "--pc-wizard",
+        "--preset",
+        "fighter",
+        "--out",
+        str(out),
+    ]
+    proc = subprocess.run(args, text=True, capture_output=True, timeout=20, cwd=str(main_path.parent))
+    assert proc.returncode == 0
+    assert out.exists()
+    pcs = load_party_file(out)
+    assert len(pcs) >= 1


### PR DESCRIPTION
## Summary
- resolve campaign folders and auto-start scenes unless overridden
- allow campaign encounters to run interactively and require PCs
- add simple CLI PC wizard with fighter/rogue/wizard presets

## Testing
- `pytest`
- `python -m grimbrain --campaign campaigns/goblin-raids --save /tmp/dev.json --seed 42 --max-rounds 0 <<'EOF'
2
EOF`
- `python -m grimbrain --campaign campaigns/goblin-raids --play --pc pc.json --start ambush --seed 42 --max-rounds 1 <<'EOF'
end
EOF`


------
https://chatgpt.com/codex/tasks/task_e_689b6c16802083279e4c81c2bb4317b1