### PR TITLE
Enhance campaign variety, rest and difficulty options

### DIFF
--- a/grimbrain/content/select.py
+++ b/grimbrain/content/select.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import List, Set
+
+# Root directory containing monster packs. Tests may monkeypatch this.
+PACK_ROOT = Path(__file__).resolve().parents[2] / "packs"
+
+
+def _parse_cr(value: str | float | int | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        try:
+            num, den = value.split("/")
+            return float(int(num) / int(den))
+        except Exception:
+            return None
+
+
+def _build_index(root: Path) -> List[dict]:
+    entries: List[dict] = []
+    if not root.exists():
+        return entries
+    for path in root.rglob("*.json"):
+        try:
+            data = json.loads(path.read_text())
+        except Exception:
+            continue
+        name = data.get("name")
+        if not name:
+            continue
+        cr = _parse_cr(data.get("cr"))
+        tags = [t.lower() for t in data.get("tags", [])]
+        entries.append({"name": name, "cr": cr, "tags": set(tags)})
+    return entries
+
+
+def select_monster(
+    tags: list[str] | None = None,
+    cr: str | None = None,
+    exclude: Set[str] | None = None,
+    seed: int | None = None,
+) -> str:
+    """Pick a monster from local packs deterministically by seed."""
+
+    exclude_l = {e.lower() for e in (exclude or set())}
+    index = _build_index(PACK_ROOT)
+
+    candidates = []
+    for entry in index:
+        if entry["name"].lower() in exclude_l:
+            continue
+        if tags and not set(t.lower() for t in tags).issubset(entry["tags"]):
+            continue
+        if cr:
+            if "-" in cr:
+                lo, hi = cr.split("-", 1)
+                try:
+                    lo_f = float(lo)
+                    hi_f = float(hi)
+                    c = entry["cr"]
+                    if c is None or not (lo_f <= c <= hi_f):
+                        continue
+                except ValueError:
+                    pass
+            else:
+                try:
+                    target = float(cr)
+                    if entry["cr"] != target:
+                        continue
+                except ValueError:
+                    pass
+        candidates.append(entry["name"])
+
+    if not candidates:
+        raise ValueError("No monsters match criteria")
+    rng = random.Random(seed)
+    candidates.sort()
+    return rng.choice(candidates)

--- a/grimbrain/engine/encounter.py
+++ b/grimbrain/engine/encounter.py
@@ -40,3 +40,33 @@ def compute_encounter(monsters: List[MonsterSidecar]) -> dict:
     band, mult = _band_for_count(count)
     adjusted = int(total * mult)
     return {"total_xp": total, "adjusted_xp": adjusted, "band": band}
+
+
+def apply_difficulty(
+    monsters: List[MonsterSidecar],
+    difficulty: str = "normal",
+    scale: bool = False,
+    party_size: int = 1,
+) -> dict:
+    """Apply difficulty and scaling modifiers to monsters."""
+    hp_mult = 1.0
+    to_hit = 0
+    if difficulty == "easy":
+        hp_mult *= 0.85
+        to_hit -= 1
+    elif difficulty == "hard":
+        hp_mult *= 1.15
+        to_hit += 1
+    if scale:
+        mult = 0.9 + 0.05 * (party_size - 2)
+        mult = max(0.8, min(1.2, mult))
+        hp_mult *= mult
+    for m in monsters:
+        try:
+            base = int(m.hp.split()[0])
+            m.hp = str(int(round(base * hp_mult)))
+        except Exception:
+            pass
+        for a in m.actions_struct:
+            a.attack_bonus += to_hit
+    return {"hp_mult": hp_mult, "to_hit": to_hit}

--- a/grimbrain/engine/rests.py
+++ b/grimbrain/engine/rests.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import random
+from typing import Iterable
+
+from .dice import roll
+from ..models import PC
+
+
+def apply_short_rest(pcs: Iterable[PC], rng: random.Random | None = None) -> dict:
+    """Apply a short rest to PCs, returning healing deltas."""
+    rng = rng or random.Random()
+    deltas: dict[str, int] = {}
+    for pc in pcs:
+        seed = rng.randint(0, 10_000_000)
+        heal = roll("1d8", seed=seed)["total"] + getattr(pc, "con_mod", 0)
+        heal = max(1, heal)
+        before = pc.hp
+        pc.hp = min(pc.hp + heal, pc.max_hp)
+        deltas[pc.name] = pc.hp - before
+    return deltas
+
+
+def apply_long_rest(pcs: Iterable[PC]) -> dict:
+    """Fully heal PCs."""
+    deltas: dict[str, int] = {}
+    for pc in pcs:
+        before = pc.hp
+        pc.hp = pc.max_hp
+        deltas[pc.name] = pc.hp - before
+    return deltas

--- a/grimbrain/models.py
+++ b/grimbrain/models.py
@@ -69,6 +69,15 @@ class PC(BaseModel):
     ac: int
     hp: int
     attacks: List[Attack]
+    max_hp: int | None = None
+    con_mod: int = 0
+
+    def __init__(self, **data):  # type: ignore[override]
+        if data.get("max_hp") is None and "hp" in data:
+            data["max_hp"] = data.get("hp")
+        if data.get("con_mod") is None:
+            data["con_mod"] = 0
+        super().__init__(**data)
 
 
 def dump_model(m: BaseModel) -> Dict[str, Any]:

--- a/tests/test_campaign_cli.py
+++ b/tests/test_campaign_cli.py
@@ -142,3 +142,23 @@ def test_encounter_requires_pcs(tmp_path):
     proc = run_cli(tmp_path, "", extra=["--max-rounds", "0"])
     assert proc.returncode != 0
     assert "no pcs were loaded" in proc.stderr.lower()
+
+
+def test_rest_scene_save_resume(tmp_path):
+    pc = {"name": "Hero", "ac": 15, "hp": 5, "max_hp": 10, "attacks": []}
+    (tmp_path / "pc.json").write_text(json.dumps(pc))
+    campaign = {
+        "name": "RestDemo",
+        "party_files": ["pc.json"],
+        "start": "rest",
+        "scenes": {
+            "rest": {"text": "resting", "rest": "short", "on_victory": "end", "on_defeat": "end"},
+            "end": {"text": "end"},
+        },
+    }
+    (tmp_path / "campaign.yaml").write_text(yaml.safe_dump(campaign))
+    save_path = tmp_path / "state.json"
+    run_campaign_cli(tmp_path / "campaign.yaml", save=str(save_path), seed=1)
+    state = json.loads(save_path.read_text())
+    assert state["hp"]["Hero"] > 5
+    run_campaign_cli(tmp_path / "campaign.yaml", resume=str(save_path))

--- a/tests/test_campaign_variety.py
+++ b/tests/test_campaign_variety.py
@@ -1,0 +1,51 @@
+import json
+import yaml
+from pathlib import Path
+
+from main import run_campaign_cli
+from grimbrain.content import select
+
+
+def test_random_encounter_variety(tmp_path, monkeypatch):
+    pack_dir = tmp_path / "packs"
+    pack_dir.mkdir()
+    (pack_dir / "goblin.json").write_text(json.dumps({"name": "Goblin", "cr": "1", "tags": ["goblinoid"]}))
+    (pack_dir / "goblin boss.json").write_text(json.dumps({"name": "Goblin Boss", "cr": "2", "tags": ["goblinoid"]}))
+    monkeypatch.setattr(select, "PACK_ROOT", pack_dir)
+
+    pc = {"name": "Hero", "ac": 15, "hp": 10, "attacks": [{"name": "Sword", "to_hit": 5, "damage_dice": "1d6", "type": "melee"}]}
+    (tmp_path / "pc.json").write_text(json.dumps(pc))
+    campaign = {
+        "name": "Variety",
+        "party_files": ["pc.json"],
+        "start": "a",
+        "scenes": {
+            "a": {
+                "text": "A",
+                "encounter": {
+                    "random": {"tags": ["goblinoid"], "cr": "1-2", "exclude_seen": True}
+                },
+                "on_victory": "b",
+                "on_defeat": "b",
+            },
+            "b": {
+                "text": "B",
+                "encounter": {
+                    "random": {"tags": ["goblinoid"], "cr": "1-2", "exclude_seen": True}
+                },
+                "on_victory": "end",
+                "on_defeat": "end",
+            },
+            "end": {"text": "End"},
+        },
+    }
+    (tmp_path / "campaign.yaml").write_text(yaml.safe_dump(campaign))
+    seen = []
+
+    def _run(pcs, enemy, **kwargs):
+        seen.append(enemy)
+        return {"result": "victory", "summary": "", "hp": {p.name: p.hp for p in pcs}}
+
+    monkeypatch.setattr("grimbrain.engine.campaign.run_encounter", _run)
+    run_campaign_cli(tmp_path / "campaign.yaml", seed=1)
+    assert len(seen) == 2 and seen[0].lower() != seen[1].lower()

--- a/tests/test_content_select.py
+++ b/tests/test_content_select.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+from grimbrain.content import select
+
+
+def test_select_exclude(tmp_path, monkeypatch):
+    pack_dir = tmp_path / "packs"
+    pack_dir.mkdir()
+    (pack_dir / "goblin.json").write_text(json.dumps({"name": "Goblin", "cr": "1", "tags": ["goblinoid"]}))
+    (pack_dir / "goblin boss.json").write_text(
+        json.dumps({"name": "Goblin Boss", "cr": "2", "tags": ["goblinoid"]})
+    )
+    monkeypatch.setattr(select, "PACK_ROOT", pack_dir)
+    for _ in range(5):
+        assert select.select_monster(tags=["goblinoid"], cr="1-2", exclude={"goblin boss"}, seed=1) == "Goblin"

--- a/tests/test_difficulty.py
+++ b/tests/test_difficulty.py
@@ -1,0 +1,23 @@
+from grimbrain.engine.encounter import apply_difficulty
+from grimbrain.fallback_monsters import FALLBACK_MONSTERS
+from grimbrain.models import MonsterSidecar
+
+
+def _mon():
+    return MonsterSidecar(**FALLBACK_MONSTERS["goblin"])
+
+
+def test_difficulty_hp_changes():
+    m_easy = _mon()
+    m_hard = _mon()
+    apply_difficulty([m_easy], "easy", False, 2)
+    apply_difficulty([m_hard], "hard", False, 2)
+    assert int(m_easy.hp) < int(m_hard.hp)
+
+
+def test_scaling_party_size():
+    m_small = _mon()
+    m_large = _mon()
+    apply_difficulty([m_small], "normal", True, 2)
+    apply_difficulty([m_large], "normal", True, 5)
+    assert int(m_small.hp) < int(m_large.hp)

--- a/tests/test_play_parser.py
+++ b/tests/test_play_parser.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_pc(tmp_path, party):
+    path = tmp_path / "pc.json"
+    path.write_text(json.dumps({"party": party}))
+    return path
+
+
+def run_play(cmds: str, pc_file: Path, encounter: str, seed: int | None = None) -> subprocess.CompletedProcess:
+    main_path = Path(__file__).resolve().parent.parent / "main.py"
+    args = [sys.executable, str(main_path), "--play", "--pc", str(pc_file), "--encounter", encounter]
+    if seed is not None:
+        args += ["--seed", str(seed)]
+    return subprocess.run(
+        args,
+        input=cmds,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        cwd=str(main_path.parent),
+    )
+
+
+def test_default_actor(tmp_path):
+    pcs = [
+        {"name": "Malrick", "ac": 15, "hp": 20, "attacks": [{"name": "Shortsword", "to_hit": 5, "damage_dice": "1d6+3", "type": "melee"}]}
+    ]
+    pc_file = _write_pc(tmp_path, pcs)
+    script = "a Goblin \"Shortsword\"\nend\n"
+    res = run_play(script, pc_file, "goblin", seed=1)
+    assert "Malrick hits Goblin" in res.stdout
+
+
+def test_wrong_actor_hint(tmp_path):
+    pcs = [
+        {"name": "Malrick", "ac": 15, "hp": 20, "attacks": [{"name": "Shortsword", "to_hit": 5, "damage_dice": "1d6+3", "type": "melee"}]},
+        {"name": "Brynn", "ac": 14, "hp": 20, "attacks": [{"name": "Shortsword", "to_hit": 4, "damage_dice": "1d6+2", "type": "melee"}]},
+    ]
+    pc_file = _write_pc(tmp_path, pcs)
+    script = "a Malrick Goblin \"Shortsword\"\nq\n"
+    res = run_play(script, pc_file, "goblin", seed=1)
+    assert "It's Brynn's turn." in res.stdout
+
+
+def test_downed_actor_error(tmp_path):
+    pcs = [
+        {"name": "Malrick", "ac": 15, "hp": 20, "attacks": [{"name": "Shortsword", "to_hit": 5, "damage_dice": "1d6+3", "type": "melee"}]},
+        {"name": "Brynn", "ac": 14, "hp": 0, "max_hp": 10, "attacks": [{"name": "Shortsword", "to_hit": 4, "damage_dice": "1d6+2", "type": "melee"}]},
+    ]
+    pc_file = _write_pc(tmp_path, pcs)
+    script = "a Brynn Goblin \"Shortsword\"\nq\n"
+    res = run_play(script, pc_file, "goblin", seed=1)
+    assert "Brynn is at 0 HP and cannot act" in res.stdout

--- a/tests/test_rests.py
+++ b/tests/test_rests.py
@@ -1,0 +1,19 @@
+import random
+
+from grimbrain.engine import rests
+from grimbrain.models import PC
+
+
+def test_short_rest_heals(tmp_path):
+    pc = PC(name="Hero", ac=10, hp=5, max_hp=10, con_mod=2, attacks=[])
+    rng = random.Random(1)
+    deltas = rests.apply_short_rest([pc], rng)
+    assert 0 < deltas["Hero"] <= 10
+    assert pc.hp <= pc.max_hp
+
+
+def test_long_rest_full_heal():
+    pc = PC(name="Hero", ac=10, hp=3, max_hp=10, attacks=[])
+    deltas = rests.apply_long_rest([pc])
+    assert deltas["Hero"] == 7
+    assert pc.hp == 10


### PR DESCRIPTION
## Summary
- Add deterministic monster selector and tracking to avoid repeats
- Introduce short/long rest utilities with PC max HP and con modifier
- Improve play CLI with attacker hints, downed checks, and difficulty/scale modifiers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b8afdd7648327b17d38d06ac8ac03