### PR TITLE
Add basic 5e rules core with tests

### DIFF
--- a/grimbrain/rules/__init__.py
+++ b/grimbrain/rules/__init__.py
@@ -1,0 +1,25 @@
+from .core import (
+    mod,
+    prof_bonus,
+    ability_mods_from_scores,
+    ArmorProfile,
+    ac_calc,
+    resolve_attack_ability,
+    attack_bonus,
+    initiative_bonus,
+    roll_attack,
+    roll_damage,
+)
+
+__all__ = [
+    "mod",
+    "prof_bonus",
+    "ability_mods_from_scores",
+    "ArmorProfile",
+    "ac_calc",
+    "resolve_attack_ability",
+    "attack_bonus",
+    "initiative_bonus",
+    "roll_attack",
+    "roll_damage",
+]

--- a/grimbrain/rules/core.py
+++ b/grimbrain/rules/core.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Callable, Dict, Literal, Optional, Tuple
+
+AdvMode = Literal["normal", "adv", "dis"]
+
+# ---------- Ability & proficiency ---------------------------------------------
+
+def mod(score: int) -> int:
+    """5e ability modifier from ability score."""
+    return (score - 10) // 2
+
+def prof_bonus(level: int) -> int:
+    """5e proficiency bonus by level (SRD table)."""
+    if level <= 0:
+        return 2
+    if level <= 4:
+        return 2
+    if level <= 8:
+        return 3
+    if level <= 12:
+        return 4
+    if level <= 16:
+        return 5
+    return 6
+
+def ability_mods_from_scores(scores: Dict[str, int]) -> Dict[str, int]:
+    """Return {STR,DEX,CON,INT,WIS,CHA} -> modifier."""
+    return {k: mod(v) for k, v in scores.items()}
+
+# ---------- Armor Class -------------------------------------------------------
+
+@dataclass(frozen=True)
+class ArmorProfile:
+    """Armor profile for AC computation."""
+    base: int                                  # e.g., 11 for leather, 14 for chain shirt
+    kind: Literal["light", "medium", "heavy"]
+    dex_cap: Optional[int] = None              # None=unlimited; 2 for medium; 0 for heavy
+
+def ac_calc(armor: ArmorProfile, dex_mod: int, shield_bonus: int = 0, misc: int = 0) -> int:
+    if armor.kind == "light":
+        dex = dex_mod
+    elif armor.kind == "medium":
+        cap = 2 if armor.dex_cap is None else armor.dex_cap
+        dex = min(dex_mod, cap)
+    else:  # heavy
+        dex = 0
+    return armor.base + dex + shield_bonus + misc
+
+# ---------- Attacks & initiative ---------------------------------------------
+
+def resolve_attack_ability(weapon: Dict) -> Literal["STR", "DEX"]:
+    """
+    Choose ability for attacks:
+      - Ranged or finesse -> DEX
+      - Otherwise -> STR
+    `weapon` example: {"type":"melee","finesse":True,"ranged":False}
+    """
+    if weapon.get("ranged"):
+        return "DEX"
+    if weapon.get("finesse"):
+        return "DEX"
+    return "STR"
+
+def attack_bonus(ability_mod: int, proficient: bool, level: int, misc: int = 0) -> int:
+    return ability_mod + (prof_bonus(level) if proficient else 0) + misc
+
+def initiative_bonus(dex_mod: int, misc: int = 0) -> int:
+    return dex_mod + misc
+
+# ---------- Rolling helpers (injectable RNG) ----------------------------------
+
+def _d20(rng) -> int:
+    return rng.randint(1, 20)
+
+def roll_attack(to_hit: int, adv: AdvMode = "normal", rng=None) -> Tuple[int, bool, bool, int]:
+    """
+    Roll a d20 with advantage/disadvantage and add `to_hit`.
+    Returns (total, is_crit, is_natural1, face).
+    Crit on natural 20. Natural 1 flagged; auto-miss semantics left to engine.
+    """
+    import random
+    rng = rng or random.Random()
+    a = _d20(rng)
+    if adv == "normal":
+        face = a
+    else:
+        b = _d20(rng)
+        face = max(a, b) if adv == "adv" else min(a, b)
+    is_crit = face == 20
+    is_n1 = face == 1
+    return face + to_hit, is_crit, is_n1, face
+
+def roll_damage(
+    dice_expr: str,
+    mod_val: int = 0,
+    crit: bool = False,
+    roller: Optional[Callable[[str], int]] = None,
+) -> int:
+    """
+    Roll damage dice + mod. On crit, doubles *dice only* (not the modifier).
+    `roller(expr)` should return the result of rolling the dice expression (e.g., "1d8").
+    If not provided, uses a minimal internal roller (not guaranteed deterministic).
+    """
+    def _parse(expr: str) -> Tuple[int, int]:
+        n_s, d_s = expr.lower().split("d")
+        return int(n_s), int(d_s)
+
+    if roller is None:
+        import random
+        rnd = random.Random()
+        def roller(expr: str) -> int:
+            n, d = _parse(expr)
+            return sum(rnd.randint(1, d) for _ in range(n))
+
+    dice_total = roller(dice_expr)
+    if crit:
+        dice_total += roller(dice_expr)
+    return dice_total + mod_val

--- a/tests/rules/test_ac_and_attacks.py
+++ b/tests/rules/test_ac_and_attacks.py
@@ -1,0 +1,61 @@
+import random
+from grimbrain.rules import (
+    ArmorProfile,
+    ac_calc,
+    resolve_attack_ability,
+    attack_bonus,
+    initiative_bonus,
+    roll_attack,
+    roll_damage,
+)
+
+def test_ac_calc_light_medium_heavy():
+    dex_mod = 3
+    # Light (e.g., Leather 11 + Dex)
+    ac_light = ac_calc(ArmorProfile(base=11, kind="light"), dex_mod, shield_bonus=0)
+    assert ac_light == 14
+
+    # Medium (e.g., Chain Shirt 14 + Dex (max 2))
+    ac_medium = ac_calc(ArmorProfile(base=14, kind="medium", dex_cap=2), dex_mod, shield_bonus=0)
+    assert ac_medium == 16
+
+    # Heavy (e.g., Chain Mail 16 + Shield 2, Dex ignored)
+    ac_heavy = ac_calc(ArmorProfile(base=16, kind="heavy", dex_cap=0), dex_mod, shield_bonus=2)
+    assert ac_heavy == 18
+
+def test_attack_math_and_initiative():
+    # Finesse weapon -> DEX
+    weapon = {"type": "melee", "finesse": True, "ranged": False}
+    assert resolve_attack_ability(weapon) == "DEX"
+
+    # Attack bonus: ability + prof(level) + misc
+    to_hit = attack_bonus(ability_mod=3, proficient=True, level=5, misc=1)
+    assert to_hit == 7  # 3 + prof(5)=3 + 1
+
+    # Initiative bonus
+    assert initiative_bonus(dex_mod=3, misc=1) == 4
+
+def test_roll_attack_advantage_and_disadvantage_are_deterministic_with_seed():
+    rng = random.Random(42)
+    total, is_crit, is_n1, face = roll_attack(to_hit=5, adv="normal", rng=rng)
+    assert (total, is_crit, is_n1, face) == (9, False, False, 4)
+
+    rng = random.Random(42)
+    total, is_crit, is_n1, face = roll_attack(to_hit=5, adv="adv", rng=rng)
+    assert (total, is_crit, is_n1, face) == (9, False, False, 4)
+
+    rng = random.Random(42)
+    total, is_crit, is_n1, face = roll_attack(to_hit=5, adv="dis", rng=rng)
+    assert (total, is_crit, is_n1, face) == (6, False, True, 1)
+
+def test_roll_damage_and_crit_doubles_dice_only():
+    # Deterministic roller for unit tests
+    fixed = {"1d8": 5, "2d6": 7}
+    def roller(expr: str) -> int:
+        return fixed[expr]
+
+    # Normal hit: 1d8 + 3 == 5 + 3
+    assert roll_damage("1d8", mod_val=3, crit=False, roller=roller) == 8
+
+    # Crit: doubles dice only: (1d8 + 1d8) + 3 == 5 + 5 + 3
+    assert roll_damage("1d8", mod_val=3, crit=True, roller=roller) == 13

--- a/tests/rules/test_core_math.py
+++ b/tests/rules/test_core_math.py
@@ -1,0 +1,19 @@
+from grimbrain.rules import mod, prof_bonus, ability_mods_from_scores
+
+def test_mod_table():
+    assert mod(8) == -1
+    assert mod(10) == 0
+    assert mod(15) == 2
+    assert mod(18) == 4
+
+def test_prof_bonus_table():
+    assert prof_bonus(1) == 2
+    assert prof_bonus(5) == 3
+    assert prof_bonus(9) == 4
+    assert prof_bonus(13) == 5
+    assert prof_bonus(17) == 6
+
+def test_ability_mods_from_scores():
+    scores = {"STR": 14, "DEX": 12, "CON": 10, "INT": 8, "WIS": 16, "CHA": 9}
+    mods = ability_mods_from_scores(scores)
+    assert mods == {"STR": 2, "DEX": 1, "CON": 0, "INT": -1, "WIS": 3, "CHA": -1}


### PR DESCRIPTION
## Summary
- Add `grimbrain.rules` package with pure 5e helper functions for ability mods, armor class, attacks, and damage
- Provide deterministic dice helpers and initiative/attack calculations
- Test core math, armor, attack rolls, and damage behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b9a507b7c83278ee7dd71bd5618e3