### PR TITLE
Add missing md-out CLI flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -729,6 +729,7 @@ def main():
     parser.add_argument("--preset", choices=["fighter", "rogue", "wizard"], help="Preset party for --pc-wizard", default=None)
     parser.add_argument("--force", action="store_true", help="Force reindexing of the vector store")
     parser.add_argument("--json-out", nargs="?", const="logs/last_sidecar.json", help="Write sidecar JSON to path", default=None)
+    parser.add_argument("--md-out", nargs="?", const="logs/last_query.md", help="Write Markdown output to path", default=None)
     parser.add_argument("--scene", type=str, help="Start a seed encounter", default=None)
     parser.add_argument("--resume", type=str, help="Resume session from JSON file", default=None)
     parser.add_argument(


### PR DESCRIPTION
## Summary
- add `--md-out` argument to CLI to handle markdown output path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c99e224148327a8676ebed4e7d6f4