### PR TITLE
Replace unicode arrow in help tag with ASCII

### DIFF
--- a/main.py
+++ b/main.py
@@ -162,7 +162,7 @@ def _print_status(
                 if st.hidden:
                     tags += " [Hidden]"
                 if st.help_advantage_token:
-                    tags += " [Help→]"
+                    tags += " [Help]"
         print(f"{c.name}: {hp}, AC {c.ac}{tags}")
 
 

--- a/tests/test_play_actions_cli.py
+++ b/tests/test_play_actions_cli.py
@@ -65,7 +65,7 @@ def test_help_consumed(tmp_path):
     res = run_play(script, pc_file, "goblin", seed=5)
     out = res.stdout
     assert "Brynn helps Malrick" in out
-    assert out.count("[Help→]") == 1
+    assert out.count("[Help]") == 1
 
 
 def test_hide_consumed(tmp_path):


### PR DESCRIPTION
## Summary
- Avoid Unicode encoding problems on Windows by using `[Help]` rather than `[Help→]` for help action status tags
- Update tests to check for the new help tag

## Testing
- `pytest tests/test_play_actions_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb31e6f6c8327a222e9d369aecda9