### PR TITLE
Ensure PCs retain proper max HP

### DIFF
--- a/main.py
+++ b/main.py
@@ -355,7 +355,18 @@ def play_cli(
 
     combatants: list[Combatant] = []
     combatants.extend(
-        [Combatant(p.name, p.ac, p.hp, [dump_model(a) for a in p.attacks], "party", getattr(p, "dex_mod", 0)) for p in pcs]
+        [
+            Combatant(
+                p.name,
+                p.ac,
+                p.hp,
+                [dump_model(a) for a in p.attacks],
+                "party",
+                getattr(p, "dex_mod", 0),
+                max_hp=p.max_hp,
+            )
+            for p in pcs
+        ]
     )
     for c, p in zip(combatants, pcs):
         c.str_mod = getattr(p, "str_mod", 0)


### PR DESCRIPTION
## Summary
- initialize combatants with their defined max_hp value so healing works correctly

## Testing
- `pytest tests/test_death_saves_cli.py::test_heal_command_clears_down tests/test_death_saves_cli.py::test_stable_then_damage_breaks_stability -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4a23a36c832794c137b8ebdfc183