### PR TITLE
Implement spell slot tracking and concentration checks

### DIFF
--- a/grimbrain/models.py
+++ b/grimbrain/models.py
@@ -59,6 +59,7 @@ class Attack(BaseModel):
     save_dc: int | None = None
     save_ability: str | None = None
     spell: SpellSidecar | None = None
+    level: int | None = None
     concentration: bool = False
 
 
@@ -74,6 +75,7 @@ class PC(BaseModel):
     hit_die_size: int = 8
     hit_dice_max: int = 1
     hit_dice: int | None = None
+    spell_slots: Dict[int, int] = Field(default_factory=dict)
 
     def __init__(self, **data):  # type: ignore[override]
         if data.get("max_hp") is None and "hp" in data:

--- a/tests/test_spellcasting_combat.py
+++ b/tests/test_spellcasting_combat.py
@@ -19,7 +19,17 @@ caster = PC(
     name="Mage",
     ac=12,
     hp=20,
-    attacks=[Attack(name="Fireball", damage_dice="8d6", type="spell", save_dc=13, save_ability="dex", spell=fireball)],
+    attacks=[
+        Attack(
+            name="Fireball",
+            damage_dice="8d6",
+            type="spell",
+            save_dc=13,
+            save_ability="dex",
+            spell=fireball,
+        )
+    ],
+    spell_slots={3: 1},
 )
 
 
@@ -29,3 +39,48 @@ def test_fireball_saves_and_damage():
     mons = res["state"]["monsters"]
     losses = [7 - m["hp"] for m in mons]
     assert losses == [28, 28, 14]
+
+
+def test_spell_slot_depletion():
+    tough = make_goblin()
+    tough.hp = "100"
+    res = run_encounter([caster], [tough], seed=1, max_rounds=2)
+    mons = res["state"]["monsters"]
+    # Only one casting due to a single slot
+    assert 0 < mons[0]["hp"] < 100
+
+
+def test_concentration_breaks_on_damage():
+    bolt = SpellSidecar(
+        name="Bolt",
+        level=1,
+        school="Evocation",
+        casting_time="1 action",
+        range="120 feet",
+        components="V,S",
+        duration="Concentration",
+        classes=["Wizard"],
+        text="Bolt",
+        provenance=["PHB"],
+    )
+    conc_caster = PC(
+        name="Mage",
+        ac=12,
+        hp=20,
+        attacks=[
+            Attack(
+                name="Bolt",
+                damage_dice="1d6",
+                type="spell",
+                to_hit=5,
+                spell=bolt,
+                concentration=True,
+                level=1,
+            )
+        ],
+        spell_slots={1: 1},
+        con_mod=0,
+    )
+    goblin = make_goblin()
+    res = run_encounter([conc_caster], [goblin], seed=9, max_rounds=1)
+    assert any("loses concentration" in l for l in res["log"])


### PR DESCRIPTION
## Summary
- track spell slots and basic concentration for casters
- extend character sheet helpers with spell attack bonus and slot parsing
- add tests for spellcasting slot usage and concentration loss

## Testing
- `GB_TESTING=1 python -m pytest tests/test_character_sheet.py::test_load_sheet_and_helpers -q`
- `GB_TESTING=1 python -m pytest tests/test_spellcasting_combat.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e12e136848327b533348633b41e0e