### PR TITLE
Use ASCII arrow for healing log

### DIFF
--- a/main.py
+++ b/main.py
@@ -210,7 +210,7 @@ def heal_target(target: Combatant, amount: int) -> str:
         target.defeated = False
         cleared = True
     note = "; death saves cleared" if cleared else ""
-    return f"{target.name} heals {amount} (HP {before} → {target.hp}){note}"
+    return f"{target.name} heals {amount} (HP {before} -> {target.hp}){note}"
 
 
 def _print_status(

--- a/tests/test_heal_potion_cli.py
+++ b/tests/test_heal_potion_cli.py
@@ -84,5 +84,5 @@ def test_potion_routes_to_heal_helper(tmp_path):
     out = _run(script, pc_file, seed=13).stdout
     assert "Potion of Healing on Mal: rolled 2d4+2 =" in out
     assert "Mal heals" in out
-    assert "HP 0 →" in out
+    assert "HP 0 ->" in out
     assert "death saves cleared" in out


### PR DESCRIPTION
## Summary
- avoid Unicode encoding problems by using ASCII '->' in heal_target messages
- adjust healing potion CLI test to expect new arrow

## Testing
- `pytest tests/test_heal_potion_cli.py::test_potion_routes_to_heal_helper -q`


------
https://chatgpt.com/codex/tasks/task_e_689e1ecd03488327affc53399d71e98b