### PR TITLE
Implement Hit Dice rest mechanics

### DIFF
--- a/grimbrain/engine/rests.py
+++ b/grimbrain/engine/rests.py
@@ -37,17 +37,18 @@ def apply_short_rest(
     for pc in pcs:
         _check_restable(pc)
         spend_req = spends.get(pc.name, 1) if spends else 1
-        spend = min(spend_req, max(pc.hit_dice, 0))
+        spend = min(spend_req, max(pc.hit_dice_remaining, 0))
         rolls: list[int] = []
         total = 0
         for _ in range(spend):
             seed = rng.randint(0, 10_000_000)
-            die = roll(f"1d{pc.hit_die_size}", seed=seed)["total"]
+            die_size = int(pc.hit_die.lstrip("d"))
+            die = roll(f"1d{die_size}", seed=seed)["total"]
             rolls.append(die)
             total += max(0, die + pc.con_mod)
         before = pc.hp
         pc.hp = min(pc.hp + total, pc.max_hp)
-        pc.hit_dice = max(pc.hit_dice - spend, 0)
+        pc.hit_dice_remaining = max(pc.hit_dice_remaining - spend, 0)
         deltas[pc.name] = {
             "healed": pc.hp - before,
             "rolls": rolls,
@@ -63,10 +64,12 @@ def apply_long_rest(pcs: Iterable[PC]) -> dict:
         _check_restable(pc)
         before = pc.hp
         pc.hp = pc.max_hp
-        recover = pc.hit_dice_max // 2
-        missing = pc.hit_dice_max - pc.hit_dice
+        recover = pc.hit_dice_total // 2
+        missing = pc.hit_dice_total - pc.hit_dice_remaining
         recover = min(recover, missing)
-        pc.hit_dice += recover
+        pc.hit_dice_remaining += recover
+        # restore spell slots to max
+        pc.spell_slots = pc.spell_slots_total.copy()
         deltas[pc.name] = {
             "healed": pc.hp - before,
             "hd_regained": recover,


### PR DESCRIPTION
## Summary
- Track PC hit dice and spell slots separately for rests
- Expand rest handling with detailed short/long rest logic and status display
- Cover hit dice recovery and max-HP clamping in tests

## Testing
- `pytest tests/test_rests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e2f1c490083279ad6477999aaea32