### PR TITLE
Implement data-driven rules engine with CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,26 @@ function always returns a `(markdown, json, provenance)` tuple.
 - `--md-out` writes the markdown output
 - `--play` enables interactive combat
 - `--autosave` appends turn summaries to paired markdown/JSON logs
+
+## Data-driven rules (Phase 7)
+
+The new rules engine loads JSON rule documents and resolves them through a
+lightweight vector search index.  Enable it by setting ``GB_ENGINE=data``:
+
+```bash
+GB_ENGINE=data python main.py rules show attack
+```
+
+Before the first run, index your rule files:
+
+```bash
+python -m grimbrain.rules.index --rules rules --out .chroma
+```
+
+At runtime you can reload rules and rebuild the index via:
+
+```bash
+GB_ENGINE=data python main.py rules reload
+```
+
+See ``schema/rule.schema.json`` for the rule document format.

--- a/grimbrain/rules/cli.py
+++ b/grimbrain/rules/cli.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+from .resolver import RuleResolver
+from .evaluator import Evaluator
+from . import index as index_mod
+
+
+def _default_context() -> dict:
+    """Return a minimal evaluation context for tests."""
+    actor = {"name": "hero", "hp": 10, "advantage": False, "tags": set()}
+    target = {"name": "target", "hp": 10, "advantage": False, "tags": set()}
+    return {"actor": actor, "target": target, "mods": {"STR": 1}, "prof": 2}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="gb", description="Data-driven rules CLI")
+    parser.add_argument("args", nargs="*")
+    ns = parser.parse_args(argv)
+
+    rules_dir = os.getenv("GB_RULES_DIR", "rules")
+    chroma_dir = os.getenv("GB_CHROMA_DIR", ".chroma")
+    resolver = RuleResolver(rules_dir=rules_dir, chroma_dir=chroma_dir)
+
+    if ns.args and ns.args[0] == "rules":
+        if len(ns.args) >= 3 and ns.args[1] == "show":
+            rule, _ = resolver.resolve(ns.args[2])
+            if not rule:
+                print("Unknown rule")
+                return 1
+            print(json.dumps(rule, indent=2))
+            return 0
+        if len(ns.args) >= 2 and ns.args[1] == "reload":
+            index_mod.build_index(rules_dir, chroma_dir)
+            resolver.reload()
+            print("Rules reloaded")
+            return 0
+        parser.error("usage: rules [show|reload] ...")
+
+    if not ns.args:
+        parser.print_help()
+        return 0
+
+    verb = ns.args[0]
+    target = ns.args[1] if len(ns.args) > 1 else None
+
+    rule, suggestions = resolver.resolve(verb)
+    if not rule:
+        print("Unknown rule")
+        if suggestions:
+            print("Suggestions: " + ", ".join(suggestions))
+        return 1
+
+    ctx = _default_context()
+    ctx["target"] = {
+        "name": target or "target",
+        "hp": 10,
+        "advantage": False,
+        "tags": set(),
+    }
+    ev = Evaluator()
+    logs = ev.apply(rule, ctx)
+    for line in logs:
+        print(line)
+    print(json.dumps({"actor_hp": ctx["actor"]["hp"], "target_hp": ctx["target"]["hp"]}))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/grimbrain/rules/evaluator.py
+++ b/grimbrain/rules/evaluator.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, Any, List
+
+from grimbrain.engine import dice
+
+
+def _format_expr(expr: str, ctx: Dict[str, Any]) -> str:
+    expr = expr.replace("{prof}", str(ctx.get("prof", 0)))
+    mods = ctx.get("mods", {})
+    for abil, val in mods.items():
+        expr = expr.replace(f"{{mod.{abil}}}", str(val))
+    return expr
+
+
+def eval_formula(expr: str, ctx: Dict[str, Any]) -> int:
+    expr = _format_expr(expr, ctx)
+    if re.search(r"\d+d\d+", expr):
+        res = dice.roll(expr, seed=ctx.get("seed"))
+        return int(res["total"])
+    return int(eval(expr, {"__builtins__": {}}, {"min": min, "max": max}))
+
+
+class Evaluator:
+    """Minimal evaluator for data-driven rules."""
+
+    def __init__(self):
+        pass
+
+    def apply(self, rule: Dict[str, Any], ctx: Dict[str, Any]) -> List[str]:
+        logs: List[str] = []
+        effects = rule.get("effects", [])
+        for eff in effects:
+            op = eff.get("op")
+            target_name = eff.get("target", "target")
+            tgt = ctx.get(target_name)
+            if op == "damage" and tgt is not None:
+                amount = eval_formula(str(eff.get("amount", 0)), ctx)
+                tgt["hp"] = tgt.get("hp", 0) - amount
+                logs.append(f"{tgt['name']} takes {amount} damage")
+            elif op == "heal" and tgt is not None:
+                amount = eval_formula(str(eff.get("amount", 0)), ctx)
+                tgt["hp"] = tgt.get("hp", 0) + amount
+                logs.append(f"{tgt['name']} heals {amount}")
+            elif op == "tag_add" and tgt is not None:
+                tag = eff.get("tag")
+                tags = tgt.setdefault("tags", set())
+                tags.add(tag)
+            elif op == "tag_remove" and tgt is not None:
+                tag = eff.get("tag")
+                tags = tgt.setdefault("tags", set())
+                tags.discard(tag)
+            elif op == "advantage_set" and tgt is not None:
+                tgt["advantage"] = bool(eff.get("value", True))
+            elif op == "log":
+                tmpl = eff.get("template", "")
+                logs.append(tmpl.format(**ctx))
+        return logs

--- a/grimbrain/rules/index.py
+++ b/grimbrain/rules/index.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import argparse
+import json
+import hashlib
+from pathlib import Path
+from typing import Iterable
+
+try:  # pragma: no cover - chromadb is heavy but optional for tests
+    from chromadb import PersistentClient
+    from chromadb.utils import embedding_functions
+except Exception:  # pragma: no cover
+    PersistentClient = None  # type: ignore
+    embedding_functions = None  # type: ignore
+
+
+class SimpleEmbeddingFunction:
+    """Deterministic, tiny embedding function.
+
+    This avoids heavy model downloads while still exercising the vector search
+    path in tests.  It is **not** suitable for production quality retrieval but
+    suffices for unit tests where we just need a reproducible number sequence.
+    """
+
+    def __call__(self, input: Iterable[str]):  # pragma: no cover - tiny utility
+        vectors: list[list[float]] = []
+        for text in input:
+            buckets = [0.0] * 32
+            for token in text.lower().split():
+                h = int(hashlib.md5(token.encode("utf-8")).hexdigest(), 16)
+                buckets[h % 32] += 1.0
+            vectors.append(buckets)
+        return vectors
+
+    # Chroma expects a ``name`` method for persistence metadata.
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "simple"
+
+
+EMBED_FN = SimpleEmbeddingFunction()
+
+
+def load_rules(rules_dir: Path) -> list[dict]:
+    rules: list[dict] = []
+    for path in sorted(rules_dir.rglob("*.json")):
+        try:
+            rules.append(json.loads(path.read_text()))
+        except Exception as exc:  # pragma: no cover - defensive
+            raise RuntimeError(f"Failed loading rule {path}") from exc
+    return rules
+
+
+def build_index(rules_dir: str | Path, out_dir: str | Path) -> None:
+    """Index rule JSON files into a persistent Chroma collection."""
+    if PersistentClient is None:  # pragma: no cover - chromadb missing
+        raise RuntimeError("chromadb is required for rule indexing")
+
+    rules_path = Path(rules_dir)
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    client = PersistentClient(path=str(out_path))
+    # Recreate the collection on every run for determinism
+    try:
+        client.delete_collection("rules")
+    except Exception:
+        pass
+    collection = client.get_or_create_collection(
+        name="rules", embedding_function=EMBED_FN
+    )
+
+    docs: list[str] = []
+    ids: list[str] = []
+    metas: list[dict] = []
+    for rule in load_rules(rules_path):
+        rid = rule.get("id")
+        if not rid:
+            continue
+        ids.append(rid)
+        text_parts = [rid, rule.get("cli_verb", ""), " ".join(rule.get("aliases", []))]
+        docs.append(" ".join(p for p in text_parts if p))
+        meta = {
+            "id": rid,
+            "kind": rule.get("kind"),
+            "cli_verb": rule.get("cli_verb"),
+            "aliases": ",".join(rule.get("aliases", [])),
+            "subkind": rule.get("subkind"),
+            "tags": ",".join(rule.get("tags", [])),
+        }
+        metas.append(meta)
+    if ids:
+        collection.upsert(ids=ids, documents=docs, metadatas=metas)
+
+
+def main(argv: list[str] | None = None) -> int:  # pragma: no cover - thin wrapper
+    parser = argparse.ArgumentParser(description="Index grimbrain rules")
+    parser.add_argument("--rules", required=True, help="Directory of rule JSON files")
+    parser.add_argument("--out", required=True, help="Output directory for Chroma store")
+    args = parser.parse_args(argv)
+    build_index(args.rules, args.out)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/grimbrain/rules/resolver.py
+++ b/grimbrain/rules/resolver.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+import json
+import difflib
+from pathlib import Path
+from typing import Dict, Tuple, List, Optional
+from collections import OrderedDict
+
+try:  # pragma: no cover - optional dependency
+    from chromadb import PersistentClient
+except Exception:  # pragma: no cover
+    PersistentClient = None  # type: ignore
+
+from .index import EMBED_FN, load_rules
+
+
+class RuleResolver:
+    """Resolve a user verb to a rule document.
+
+    The resolver first attempts exact matches against ids, cli verbs and aliases.
+    Failing that it performs a very small vector similarity search using the
+    pre-built Chroma index.  As a final fallback a difflib fuzzy match is used so
+    tests can run without the Chroma dependency.
+    """
+
+    def __init__(self, rules_dir: str | Path | None = None, chroma_dir: str | Path | None = None):
+        self.rules_dir = Path(rules_dir or os.getenv("GB_RULES_DIR", "rules"))
+        self.chroma_dir = Path(chroma_dir or os.getenv("GB_CHROMA_DIR", ".chroma"))
+        self._cache: OrderedDict[Tuple[str, Optional[str], Optional[str]], Optional[dict]] = OrderedDict()
+        self._cache_size = 512
+        self._load_rules()
+        self._init_collection()
+
+    def _init_collection(self) -> None:
+        self.collection = None
+        if PersistentClient is None:
+            return
+        try:
+            client = PersistentClient(path=str(self.chroma_dir))
+            self.collection = client.get_collection("rules")
+        except Exception:
+            self.collection = None
+
+    def _load_rules(self) -> None:
+        self.rules: Dict[str, dict] = {}
+        self.name_map: Dict[str, str] = {}
+        for rule in load_rules(self.rules_dir):
+            rid = rule["id"]
+            self.rules[rid] = rule
+            self.name_map[rid.lower()] = rid
+            verb = rule.get("cli_verb")
+            if verb:
+                self.name_map[verb.lower()] = rid
+            for alias in rule.get("aliases", []):
+                self.name_map[alias.lower()] = rid
+
+    # cache management -------------------------------------------------
+    def _cache_put(self, key, value):
+        self._cache[key] = value
+        self._cache.move_to_end(key)
+        if len(self._cache) > self._cache_size:
+            self._cache.popitem(last=False)
+
+    def reload(self) -> None:
+        self._cache.clear()
+        self._load_rules()
+        self._init_collection()
+
+    # public API -------------------------------------------------------
+    def resolve(self, text: str, kind: str | None = None, subkind: str | None = None) -> Tuple[Optional[dict], List[str]]:
+        key = (text.lower(), kind, subkind)
+        if key in self._cache:
+            result = self._cache[key]
+            if result is None:
+                return None, []
+            return result, []
+
+        # exact match --------------------------------------------------
+        rid = self.name_map.get(text.lower())
+        if rid:
+            rule = self.rules[rid]
+            self._cache_put(key, rule)
+            return rule, []
+
+        # vector search ------------------------------------------------
+        rid, score = self._vector_lookup(text, kind, subkind)
+        suggestions: List[str] = []
+        rule: Optional[dict] = None
+        if rid and score >= 0.42:
+            rule = self.rules[rid]
+        elif rid and 0.30 <= score < 0.42:
+            suggestions = [self.rules[rid]["id"]]
+        self._cache_put(key, rule)
+        return rule, suggestions
+
+    # helpers ----------------------------------------------------------
+    def _vector_lookup(self, text: str, kind: str | None, subkind: str | None) -> Tuple[Optional[str], float]:
+        if self.collection is not None:
+            where = {}
+            if kind:
+                where["kind"] = kind
+            if subkind:
+                where["subkind"] = subkind
+            try:
+                res = self.collection.query(query_texts=[text], n_results=1, where=where)
+                ids = res.get("ids", [[]])[0]
+                dists = res.get("distances", [[]])[0]
+                if ids:
+                    score = 1.0 - float(dists[0])
+                    return ids[0], score
+            except Exception:
+                pass
+        # fallback difflib --------------------------------------------
+        best_id = None
+        best_score = 0.0
+        for name, rid in self.name_map.items():
+            rule = self.rules[rid]
+            if kind and rule.get("kind") != kind:
+                continue
+            if subkind and rule.get("subkind") != subkind:
+                continue
+            s = difflib.SequenceMatcher(a=text.lower(), b=name).ratio()
+            if s > best_score:
+                best_score = s
+                best_id = rid
+        return best_id, best_score

--- a/main.py
+++ b/main.py
@@ -791,7 +791,12 @@ def run_campaign_cli(
 
     return 0
 
-def main() -> None:
+def main() -> int:
+    # Phase 7: data-driven rule engine entry point.
+    if os.getenv("GB_ENGINE") == "data":
+        from grimbrain.rules.cli import main as rules_main  # lazy import
+        return rules_main(sys.argv[1:])
+
     parser = argparse.ArgumentParser(description="Grimbrain CLI")
     parser.add_argument("--play", action="store_true", help="Run combat simulator")
     parser.add_argument("--campaign", help="Path to campaign directory or YAML", default=None)

--- a/rules/attack.json
+++ b/rules/attack.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "attack",
+  "kind": "action",
+  "subkind": "melee",
+  "cli_verb": "attack",
+  "aliases": ["atk"],
+  "targets": ["target"],
+  "effects": [
+    {"op": "damage", "target": "target", "amount": "1d1"}
+  ],
+  "log_templates": {
+    "start": "{actor} attacks {target}"
+  }
+}

--- a/rules/heal.json
+++ b/rules/heal.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "id": "heal",
+  "kind": "action",
+  "cli_verb": "heal",
+  "targets": ["target"],
+  "effects": [
+    {"op": "heal", "target": "target", "amount": "1"}
+  ],
+  "log_templates": {}
+}

--- a/schema/rule.schema.json
+++ b/schema/rule.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Grimbrain Rule",
+  "type": "object",
+  "required": ["schema_version", "id", "kind", "cli_verb", "effects"],
+  "properties": {
+    "schema_version": {"type": "integer"},
+    "id": {"type": "string"},
+    "kind": {"type": "string"},
+    "subkind": {"type": "string"},
+    "aliases": {"type": "array", "items": {"type": "string"}},
+    "cli_verb": {"type": "string"},
+    "targets": {"type": "array", "items": {"type": "string"}},
+    "prereq": {"type": ["object", "null"]},
+    "formulas": {"type": "object"},
+    "dc": {"type": ["integer", "string"]},
+    "effects": {"type": "array", "items": {"type": "object"}},
+    "log_templates": {"type": "object"},
+    "tags": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": true
+}

--- a/tests/phase7/test_evaluator_mutation.py
+++ b/tests/phase7/test_evaluator_mutation.py
@@ -1,0 +1,42 @@
+import json
+import os
+from pathlib import Path
+
+from grimbrain.rules.resolver import RuleResolver
+from grimbrain.rules.evaluator import Evaluator
+from grimbrain.rules import index
+
+
+def _build(chroma):
+    index.build_index("rules", chroma)
+
+
+def _eval_attack(chroma):
+    res = RuleResolver(rules_dir="rules", chroma_dir=chroma)
+    rule, _ = res.resolve("attack")
+    ctx = {
+        "actor": {"name": "hero", "hp": 10, "tags": set(), "advantage": False},
+        "target": {"name": "gob", "hp": 5, "tags": set(), "advantage": False},
+        "mods": {},
+        "prof": 0,
+    }
+    Evaluator().apply(rule, ctx)
+    return ctx["target"]["hp"]
+
+
+def test_mutation_changes_behavior(tmp_path):
+    chroma = tmp_path / "chroma"
+    _build(chroma)
+    before = _eval_attack(chroma)
+    path = Path("rules/attack.json")
+    orig = path.read_text()
+    try:
+        data = json.loads(orig)
+        data["effects"][0]["amount"] = "1d1+1"
+        path.write_text(json.dumps(data))
+        _build(chroma)
+        after = _eval_attack(chroma)
+    finally:
+        path.write_text(orig)
+        _build(chroma)
+    assert before != after

--- a/tests/phase7/test_reload_cache.py
+++ b/tests/phase7/test_reload_cache.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+from grimbrain.rules.resolver import RuleResolver
+from grimbrain.rules import index
+
+
+def _build(chroma):
+    index.build_index("rules", chroma)
+
+
+def test_reload_clears_cache(tmp_path):
+    chroma = tmp_path / "chroma"
+    _build(chroma)
+    res = RuleResolver(rules_dir="rules", chroma_dir=chroma)
+    rule, _ = res.resolve("swing")
+    assert rule is None
+
+    # mutate rule to include new alias
+    path = Path("rules/attack.json")
+    orig = path.read_text()
+    data = json.loads(orig)
+    data["aliases"].append("swing")
+    path.write_text(json.dumps(data))
+    _build(chroma)
+
+    # Without reload, cached miss remains
+    rule, _ = res.resolve("swing")
+    assert rule is None
+
+    res.reload()
+    rule, _ = res.resolve("swing")
+    assert rule and rule["id"] == "attack"
+
+    path.write_text(orig)  # restore
+    _build(chroma)

--- a/tests/phase7/test_resolver_cli.py
+++ b/tests/phase7/test_resolver_cli.py
@@ -1,0 +1,33 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from grimbrain.rules.resolver import RuleResolver
+from grimbrain.rules import index
+
+
+def _build_index(tmp_path: Path) -> Path:
+    out = tmp_path / "chroma"
+    index.build_index("rules", out)
+    return out
+
+
+def test_resolver_exact_and_suggestion(tmp_path):
+    chroma = _build_index(tmp_path)
+    res = RuleResolver(rules_dir="rules", chroma_dir=chroma)
+    rule, _ = res.resolve("attack")
+    assert rule and rule["id"] == "attack"
+    rule2, _ = res.resolve("atk")
+    assert rule2 and rule2["id"] == "attack"
+    rule3, sugg = res.resolve("bogus")
+    assert rule3 is None
+
+
+def test_cli_show(tmp_path):
+    chroma = _build_index(tmp_path)
+    env = os.environ | {"GB_ENGINE": "data", "GB_RULES_DIR": "rules", "GB_CHROMA_DIR": str(chroma)}
+    out = subprocess.check_output([sys.executable, "main.py", "rules", "show", "attack"], env=env, text=True)
+    data = json.loads(out)
+    assert data["id"] == "attack"

--- a/tests/phase7/test_schema.py
+++ b/tests/phase7/test_schema.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+
+import jsonschema
+
+
+def test_rules_validate_against_schema():
+    schema = json.loads(Path('schema/rule.schema.json').read_text())
+    rules_dir = Path('rules')
+    for path in rules_dir.glob('*.json'):
+        data = json.loads(path.read_text())
+        jsonschema.validate(data, schema)

--- a/tests/phase7/test_unknown_cli.py
+++ b/tests/phase7/test_unknown_cli.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from grimbrain.rules import index
+
+
+def _build_index(tmp_path: Path) -> Path:
+    out = tmp_path / "chroma"
+    index.build_index("rules", out)
+    return out
+
+
+def test_unknown_rule_cli(tmp_path):
+    chroma = _build_index(tmp_path)
+    env = os.environ | {"GB_ENGINE": "data", "GB_RULES_DIR": "rules", "GB_CHROMA_DIR": str(chroma)}
+    proc = subprocess.run([sys.executable, "main.py", "bogus"], env=env, text=True, capture_output=True)
+    assert proc.returncode == 1
+    assert "Unknown rule" in proc.stdout


### PR DESCRIPTION
## Summary
- Add JSON rule schema and sample rules
- Implement Chroma-based indexer, resolver with caching and thresholds, and evaluator for core effects
- Introduce rules CLI with show and reload commands and GB_ENGINE switch in main
- Document data-driven engine usage

## Testing
- `pytest tests/phase7 -q`
- `pytest tests/test_dice.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a00db4248c83279fc79a8104455cde