### PR TITLE
Add unit tests for utils and indexing

### DIFF
--- a/tests/test_indexing_helpers.py
+++ b/tests/test_indexing_helpers.py
@@ -1,0 +1,39 @@
+from grimbrain.retrieval import indexing
+
+
+def test_calculate_sha256(tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc")
+    expected = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    assert indexing.calculate_sha256(file_path) == expected
+
+
+def test_load_and_save_hash_cache(tmp_path, monkeypatch):
+    cache_file = tmp_path / "hash.json"
+    monkeypatch.setattr(indexing, "HASH_CACHE_FILE", str(cache_file))
+    data = {"a": "b"}
+    indexing.save_hash_cache(data)
+    assert cache_file.exists()
+    assert indexing.load_hash_cache() == data
+
+
+def test_wipe_chroma_store(tmp_path, monkeypatch):
+    store_dir = tmp_path / "chroma_store"
+    store_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    log = []
+    indexing.wipe_chroma_store(log)
+    assert not store_dir.exists()
+    assert log == [
+        {
+            "file": "ALL",
+            "entries": 0,
+            "collection": "ALL",
+            "status": "Wiped Chroma store",
+        }
+    ]
+
+
+def test_flatten_field():
+    assert indexing.flatten_field({"a": 1, "b": 2}) == "a: 1, b: 2"
+    assert indexing.flatten_field("value") == "value"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,72 @@
+import pytest
+
+from grimbrain.retrieval.utils import (
+    strip_markup,
+    normalize_name,
+    fmt_sources,
+    coerce_obj,
+    ordinal,
+    hit_text,
+)
+
+
+class DummyNode:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class DummyNodeWithScore:
+    def __init__(self, node):
+        self.node = node
+
+
+def test_strip_markup_removes_tags_and_formatting():
+    text = "This is **bold** and _italic_ {@atk mw}\n\n\nNew"
+    expected = "This is bold and italic \n\nNew"
+    assert strip_markup(text) == expected
+
+
+def test_normalize_name_cleans_markup_and_punctuation():
+    assert normalize_name(" **Goblin** ") == "goblin"
+    assert normalize_name("(Goblin)") == "goblin"
+
+
+def test_fmt_sources_filters_and_joins():
+    assert fmt_sources(["A", "", None, "B"]) == "_Sources considered:_ A · B"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("Fireball", {"text": "Fireball"}),
+        (["a", "b"], {"text": ["a", "b"]}),
+        ({"name": "Fireball"}, {"name": "Fireball"}),
+        (None, {}),
+    ],
+)
+def test_coerce_obj(value, expected):
+    assert coerce_obj(value) == expected
+
+
+@pytest.mark.parametrize(
+    "num,expected",
+    [
+        (1, "1st"),
+        (2, "2nd"),
+        (3, "3rd"),
+        (4, "4th"),
+        (11, "11th"),
+        (-1, "-1st"),
+        ("abc", "abc"),
+    ],
+)
+def test_ordinal(num, expected):
+    assert ordinal(num) == expected
+
+
+def test_hit_text_handles_various_inputs():
+    node = DummyNode("hello")
+    hit = DummyNodeWithScore(node)
+    assert hit_text(hit) == "hello"
+    assert hit_text({"text": "hi"}) == "hi"
+    assert hit_text("raw") == "raw"


### PR DESCRIPTION
## Summary
- add coverage for retrieval utility helpers
- test indexing helpers including hash cache and store wipe

## Testing
- `pytest`
- `pre-commit run --files tests/test_utils.py tests/test_indexing_helpers.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68a1197195148327871aa699c71d5a41