### PR TITLE
feat: unify content indexing and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,17 @@ python main.py rules list
 python main.py rules show attack.shortsword
 python -m grimbrain.rules.cli "attack.shortsword Goblin"
 ```
+
+## Unified content indexing
+
+The `content` command indexes rules, monsters, spells and other docs.
+
+```bash
+export GB_ENGINE="data"
+export GB_RULES_DIR="rules"
+export GB_DATA_DIR="data"
+export GB_CHROMA_DIR=".chroma"
+python main.py content reload
+python main.py content list --type monster
+python main.py content show monster/goblin
+```

--- a/data/monsters.json
+++ b/data/monsters.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "Goblin",
+    "hp": 7,
+    "ac": 15,
+    "type": "humanoid",
+    "size": "small"
+  }
+]

--- a/grimbrain/content/cli.py
+++ b/grimbrain/content/cli.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import List
+
+from grimbrain.indexing.content_index import load_sources, incremental_index, ContentDoc
+
+
+def _env_path(name: str, default: str) -> Path:
+    return Path(os.getenv(name, default))
+
+
+def _load_manifest(path: Path) -> dict:
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def cmd_reload(args) -> int:
+    chroma_dir = _env_path("GB_CHROMA_DIR", ".chroma")
+    rules_dir = _env_path("GB_RULES_DIR", "rules")
+    data_dir = _env_path("GB_DATA_DIR", "data")
+    manifest_path = chroma_dir / "manifest.json"
+
+    adapters = args.adapter or ["rules-json", "legacy-data"]
+    types_filter = set(args.types.split(",")) if args.types else set()
+    packs: List[Path] = []
+    if args.packs:
+        packs = [Path(p) for p in args.packs.split(",") if p]
+
+    docs: List[ContentDoc] = []
+    if "legacy-data" in adapters:
+        docs.extend(load_sources("legacy-data", data_dir))
+    if packs:
+        docs.extend(load_sources("packs", Path("."), packs=packs))
+    if "rules-json" in adapters:
+        docs.extend(load_sources("rules-json", rules_dir))
+
+    if types_filter:
+        docs = [d for d in docs if d.doc_type in types_filter]
+
+    res = incremental_index(docs, manifest_path, chroma_dir)
+    print(
+        f"Indexed {res.total} docs (+{res.add} / ~{res.upd} / -{res.rem}) (by_type={res.by_type}, packs={res.by_pack}, idx={res.idx})."
+    )
+    return 0
+
+
+def cmd_list(args) -> int:
+    chroma_dir = _env_path("GB_CHROMA_DIR", ".chroma")
+    manifest = _load_manifest(chroma_dir / "manifest.json")
+    for key, entry in sorted(manifest.items()):
+        dt = entry.get("doc_type")
+        if args.type and dt != args.type:
+            continue
+        if args.kind and entry.get("kind") != args.kind:
+            continue
+        if args.pack and entry.get("pack") != args.pack:
+            continue
+        line = (
+            f"{dt}/{entry.get('id')}  "
+            f"{entry.get('kind','')}/{entry.get('subkind','')}  "
+            f"[{entry.get('pack')}@{entry.get('pack_version','')}]"
+        )
+        if args.grep and args.grep not in line:
+            continue
+        print(line)
+    return 0
+
+
+def cmd_show(args) -> int:
+    chroma_dir = _env_path("GB_CHROMA_DIR", ".chroma")
+    doc_id = args.docid
+    if "/" not in doc_id:
+        print("format doc_type/id")
+        return 1
+    dt, did = doc_id.split("/", 1)
+    try:
+        from chromadb import PersistentClient
+    except Exception:
+        print("Chroma unavailable")
+        return 1
+    client = PersistentClient(path=str(chroma_dir))
+    try:
+        col = client.get_collection("content")
+    except Exception:
+        print("Not indexed")
+        return 1
+    try:
+        res = col.get(ids=[f"{dt}/{did}"])
+    except Exception:
+        print("Not found")
+        return 1
+    metas = res.get("metadatas") or []
+    if not metas:
+        print("Not found")
+        return 1
+    payload = metas[0].get("payload")
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="content")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_list = sub.add_parser("list")
+    p_list.add_argument("--type")
+    p_list.add_argument("--kind")
+    p_list.add_argument("--pack")
+    p_list.add_argument("--grep")
+    p_list.set_defaults(func=cmd_list)
+
+    p_show = sub.add_parser("show")
+    p_show.add_argument("docid")
+    p_show.set_defaults(func=cmd_show)
+
+    p_reload = sub.add_parser("reload")
+    p_reload.add_argument("--adapter", action="append")
+    p_reload.add_argument("--packs")
+    p_reload.add_argument("--types")
+    p_reload.set_defaults(func=cmd_reload)
+
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return 0
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/grimbrain/indexing/content_index.py
+++ b/grimbrain/indexing/content_index.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import json
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Dict, List, Tuple, Mapping
+
+try:  # pragma: no cover - chromadb is optional for tests
+    from chromadb import PersistentClient
+except Exception:  # pragma: no cover
+    PersistentClient = None  # type: ignore
+
+
+class SimpleEmbeddingFunction:
+    """Deterministic tiny embedding function for tests."""
+
+    def __call__(self, input: Iterable[str]):  # pragma: no cover - trivial
+        vectors: List[List[float]] = []
+        for text in input:
+            buckets = [0.0] * 32
+            for token in text.lower().split():
+                h = int(hashlib.md5(token.encode("utf-8")).hexdigest(), 16)
+                buckets[h % 32] += 1.0
+            vectors.append(buckets)
+        return vectors
+
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "simple"
+
+
+EMBED_FN = SimpleEmbeddingFunction()
+
+
+@dataclass
+class ContentDoc:
+    doc_type: str
+    id: str
+    name: str
+    kind: str | None = ""
+    subkind: str | None = ""
+    pack: str = ""
+    pack_version: str = ""
+    payload: Mapping | None = None
+    aliases: List[str] | None = None
+    metadata: Dict[str, str] | None = None
+
+
+@dataclass
+class IndexResult:
+    add: int
+    upd: int
+    rem: int
+    total: int
+    by_pack: Dict[str, int]
+    by_type: Dict[str, int]
+    idx: str
+
+
+# ---------------------------------------------------------------------------
+# helpers
+
+def _slug(name: str) -> str:
+    import re
+
+    return re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+
+
+def canonical_json(doc: Mapping) -> bytes:
+    """Return canonical JSON representation of ``doc``."""
+
+    return json.dumps(doc, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def content_signature(doc: Mapping) -> str:
+    return hashlib.sha256(canonical_json(doc)).hexdigest()
+
+
+def index_signature(items: Mapping[Tuple[str, str], str]) -> str:
+    payload = json.dumps(
+        sorted([(dt, i, sha) for (dt, i), sha in items.items()]),
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:7]
+
+
+# ---------------------------------------------------------------------------
+# loaders
+
+def load_sources(adapter: str, base_dir: str | Path, packs: List[Path] | None = None) -> Iterable[ContentDoc]:
+    base = Path(base_dir)
+    packs = packs or []
+    if adapter == "rules-json":
+        # generated first then custom so custom overrides
+        gen_dir = base / "generated"
+        if gen_dir.exists():
+            for path in sorted(gen_dir.rglob("*.json")):
+                try:
+                    rule = json.loads(path.read_text())
+                except Exception:
+                    continue
+                rid = rule.get("id") or path.stem
+                yield ContentDoc(
+                    doc_type="rule",
+                    id=rid,
+                    name=rule.get("name", rid),
+                    kind=rule.get("kind"),
+                    subkind=rule.get("subkind"),
+                    pack="generated",
+                    pack_version="",
+                    payload=rule,
+                    aliases=rule.get("aliases", []),
+                    metadata={"source": str(path)},
+                )
+        custom_dir = base / "custom"
+        src_pack = "custom"
+        if custom_dir.exists():
+            for path in sorted(custom_dir.rglob("*.json")):
+                try:
+                    rule = json.loads(path.read_text())
+                except Exception:
+                    continue
+                rid = rule.get("id") or path.stem
+                yield ContentDoc(
+                    doc_type="rule",
+                    id=rid,
+                    name=rule.get("name", rid),
+                    kind=rule.get("kind"),
+                    subkind=rule.get("subkind"),
+                    pack=src_pack,
+                    pack_version="",
+                    payload=rule,
+                    aliases=rule.get("aliases", []),
+                    metadata={"source": str(path)},
+                )
+        # flat files fallback
+        if not gen_dir.exists() and not custom_dir.exists():
+            for path in sorted(base.rglob("*.json")):
+                try:
+                    rule = json.loads(path.read_text())
+                except Exception:
+                    continue
+                rid = rule.get("id") or path.stem
+                yield ContentDoc(
+                    doc_type="rule",
+                    id=rid,
+                    name=rule.get("name", rid),
+                    kind=rule.get("kind"),
+                    subkind=rule.get("subkind"),
+                    pack="generated",
+                    pack_version="",
+                    payload=rule,
+                    aliases=rule.get("aliases", []),
+                    metadata={"source": str(path)},
+                )
+        return
+
+    if adapter == "legacy-data":
+        # weapons.json -> rule attack.<weapon>
+        wpath = base / "weapons.json"
+        if wpath.exists():
+            try:
+                weapons = json.loads(wpath.read_text())
+            except Exception:
+                weapons = []
+            for w in weapons:
+                slug = _slug(w.get("name", ""))
+                if not slug:
+                    continue
+                yield ContentDoc(
+                    doc_type="rule",
+                    id=f"attack.{slug}",
+                    name=w.get("name", slug),
+                    kind="attack",
+                    subkind=w.get("range"),
+                    pack="legacy-data",
+                    pack_version="",
+                    payload=w,
+                    aliases=[slug],
+                    metadata={"source": f"virtual:legacy-data/{wpath.name}"},
+                )
+        # spells.json -> spell
+        spath = base / "spells.json"
+        if spath.exists():
+            try:
+                spells = json.loads(spath.read_text())
+            except Exception:
+                spells = []
+            for s in spells:
+                slug = _slug(s.get("name", ""))
+                if not slug:
+                    continue
+                yield ContentDoc(
+                    doc_type="spell",
+                    id=slug,
+                    name=s.get("name", slug),
+                    kind="spell",
+                    subkind=s.get("school"),
+                    pack="legacy-data",
+                    pack_version="",
+                    payload=s,
+                    aliases=[],
+                    metadata={"source": f"virtual:legacy-data/{spath.name}"},
+                )
+        # monsters.json -> monster
+        mpath = base / "monsters.json"
+        if mpath.exists():
+            try:
+                monsters = json.loads(mpath.read_text())
+            except Exception:
+                monsters = []
+            for m in monsters:
+                slug = _slug(m.get("name", ""))
+                if not slug:
+                    continue
+                yield ContentDoc(
+                    doc_type="monster",
+                    id=slug,
+                    name=m.get("name", slug),
+                    kind=m.get("type"),
+                    subkind=m.get("size"),
+                    pack="legacy-data",
+                    pack_version="",
+                    payload=m,
+                    aliases=[],
+                    metadata={"source": f"virtual:legacy-data/{mpath.name}"},
+                )
+        return
+
+    if adapter == "packs":
+        for pack_dir in packs:
+            pjson = pack_dir / "pack.json"
+            if not pjson.exists():
+                continue
+            try:
+                meta = json.loads(pjson.read_text())
+            except Exception:
+                meta = {"name": pack_dir.name, "version": ""}
+            pack_name = meta.get("name", pack_dir.name)
+            pack_ver = meta.get("version", "")
+            for folder in ["rules", "monsters", "spells", "items", "conditions"]:
+                sub = pack_dir / folder
+                if not sub.exists():
+                    continue
+                doc_type = folder[:-1]  # plural to singular
+                for path in sorted(sub.rglob("*.json")):
+                    try:
+                        data = json.loads(path.read_text())
+                    except Exception:
+                        continue
+                    slug = _slug(data.get("id") or data.get("name") or path.stem)
+                    yield ContentDoc(
+                        doc_type=doc_type,
+                        id=slug,
+                        name=data.get("name", slug),
+                        kind=data.get("kind"),
+                        subkind=data.get("subkind"),
+                        pack=pack_name,
+                        pack_version=pack_ver,
+                        payload=data,
+                        aliases=data.get("aliases", []),
+                        metadata={"source": str(path)},
+                    )
+        return
+
+    return []
+
+
+# ---------------------------------------------------------------------------
+# indexing
+
+def incremental_index(
+    docs: Iterable[ContentDoc], manifest_path: str | Path, chroma_dir: str | Path
+) -> IndexResult:
+    manifest_file = Path(manifest_path)
+    chroma_path = Path(chroma_dir)
+    old_manifest: Dict[str, dict] = {}
+    if manifest_file.exists():
+        try:
+            old_manifest = json.loads(manifest_file.read_text())
+        except Exception:
+            old_manifest = {}
+
+    # apply precedence by iterating in order and overriding
+    final_docs: Dict[Tuple[str, str], ContentDoc] = {}
+    def _rank(d: ContentDoc) -> int:
+        if d.pack == "legacy-data":
+            return 0
+        if d.pack == "generated":
+            return 2
+        if d.pack == "custom":
+            return 3
+        return 1
+    for doc in docs:
+        key = (doc.doc_type, doc.id)
+        if key in final_docs:
+            prev = final_docs[key]
+            if _rank(prev) == _rank(doc):
+                print(f"Warning: conflict for {doc.doc_type}/{doc.id} ({prev.pack} -> {doc.pack})")
+        final_docs[key] = doc
+
+    # compute signatures and determine changes
+    new_manifest: Dict[str, dict] = {}
+    adds = 0
+    upds = 0
+    by_pack: Dict[str, int] = {}
+    by_type: Dict[str, int] = {}
+    for (dt, did), doc in final_docs.items():
+        sig = content_signature(doc.payload or {})
+        by_pack[doc.pack] = by_pack.get(doc.pack, 0) + 1
+        by_type[dt] = by_type.get(dt, 0) + 1
+        key = f"{dt}/{did}"
+        entry = {
+            "doc_type": dt,
+            "id": did,
+            "pack": doc.pack,
+            "kind": doc.kind,
+            "subkind": doc.subkind,
+            "pack_version": doc.pack_version,
+            "sha256": sig,
+            "size": len(canonical_json(doc.payload or {})),
+            "mtime": 0.0,
+        }
+        new_manifest[key] = entry
+        old = old_manifest.get(key)
+        if old is None:
+            adds += 1
+        elif old.get("sha256") != sig:
+            upds += 1
+
+    # removals
+    rem_keys = set(old_manifest) - set(new_manifest)
+    rems = len(rem_keys)
+
+    # update chroma store
+    if PersistentClient is not None:
+        client = PersistentClient(path=str(chroma_path))
+        collection = client.get_or_create_collection(
+            name="content", embedding_function=EMBED_FN
+        )
+        ids: List[str] = []
+        docs_text: List[str] = []
+        metas: List[dict] = []
+        for (dt, did), doc in final_docs.items():
+            key = f"{dt}/{did}"
+            old = old_manifest.get(key)
+            if old is None or old.get("sha256") != new_manifest[key]["sha256"]:
+                ids.append(key)
+                docs_text.append(doc.name or did)
+                metas.append(
+                    {
+                        "doc_type": dt,
+                        "id": did,
+                        "kind": doc.kind,
+                        "subkind": doc.subkind,
+                        "pack": doc.pack,
+                        "pack_version": doc.pack_version,
+                        "aliases": ",".join(doc.aliases or []),
+                        "payload": json.dumps(doc.payload or {}),
+                    }
+                )
+        if ids:
+            collection.upsert(ids=ids, documents=docs_text, metadatas=metas)
+        if rem_keys:
+            try:
+                collection.delete(ids=list(rem_keys))
+            except Exception:
+                pass
+
+    # persist manifest
+    manifest_file.parent.mkdir(parents=True, exist_ok=True)
+    manifest_file.write_text(json.dumps(new_manifest, indent=2))
+
+    # compute idx using new_manifest
+    idx = index_signature(
+        {tuple(k.split("/")): v["sha256"] for k, v in new_manifest.items()}
+    )
+
+    return IndexResult(
+        add=adds,
+        upd=upds,
+        rem=rems,
+        total=len(final_docs),
+        by_pack=by_pack,
+        by_type=by_type,
+        idx=idx,
+    )

--- a/grimbrain/rules/resolver.py
+++ b/grimbrain/rules/resolver.py
@@ -41,7 +41,7 @@ class RuleResolver:
             return
         try:
             client = PersistentClient(path=str(self.chroma_dir))
-            self.collection = client.get_collection("rules")
+            self.collection = client.get_collection("content")
         except Exception:
             self.collection = None
 
@@ -112,7 +112,7 @@ class RuleResolver:
         self, text: str, kind: str | None, subkind: str | None
     ) -> Tuple[Optional[str], float]:
         if self.collection is not None:
-            where = {}
+            where = {"doc_type": "rule"}
             if kind:
                 where["kind"] = kind
             if subkind:

--- a/main.py
+++ b/main.py
@@ -794,6 +794,9 @@ def run_campaign_cli(
 def main() -> int:
     # Phase 7: data-driven rule engine entry point.
     if os.getenv("GB_ENGINE") == "data":
+        if len(sys.argv) > 1 and sys.argv[1] == "content":
+            from grimbrain.content.cli import main as content_main
+            return content_main(sys.argv[2:])
         from grimbrain.rules.cli import main as rules_main  # lazy import
         return rules_main(sys.argv[1:])
 

--- a/tests/phase7/conftest.py
+++ b/tests/phase7/conftest.py
@@ -1,0 +1,28 @@
+import os
+import shutil
+from pathlib import Path
+import subprocess
+import sys
+import pytest
+
+
+@pytest.fixture
+def env_setup(tmp_path):
+    root = Path(__file__).resolve().parents[2]
+    rules_src = root / "rules"
+    data_src = root / "data"
+    rules_dir = tmp_path / "rules"
+    shutil.copytree(rules_src, rules_dir)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    for name in ["weapons.json", "spells.json", "monsters.json"]:
+        shutil.copy(data_src / name, data_dir / name)
+    chroma_dir = tmp_path / ".chroma"
+    env = os.environ.copy()
+    env["GB_ENGINE"] = "data"
+    env["GB_RULES_DIR"] = str(rules_dir)
+    env["GB_DATA_DIR"] = str(data_dir)
+    env["GB_CHROMA_DIR"] = str(chroma_dir)
+    # initial index
+    subprocess.run([sys.executable, "main.py", "content", "reload"], cwd=root, env=env, check=True, capture_output=True)
+    return env, root, data_dir

--- a/tests/phase7/test_content_list_filters.py
+++ b/tests/phase7/test_content_list_filters.py
@@ -1,0 +1,16 @@
+import subprocess
+import sys
+
+
+def run(cmd, env, cwd):
+    return subprocess.run(cmd, env=env, cwd=cwd, capture_output=True, text=True, check=True)
+
+
+def test_content_list_filters(env_setup):
+    env, root, _ = env_setup
+    res = run([sys.executable, "main.py", "content", "list", "--type", "monster"], env, root)
+    assert "monster/goblin" in res.stdout
+
+    res2 = run([sys.executable, "main.py", "content", "list", "--grep", "goblin"], env, root)
+    lines = [l for l in res2.stdout.splitlines() if l.strip()]
+    assert len(lines) == 1 and "goblin" in lines[0]

--- a/tests/phase7/test_content_show.py
+++ b/tests/phase7/test_content_show.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+import json
+
+
+def run(cmd, env, cwd):
+    return subprocess.run(cmd, env=env, cwd=cwd, capture_output=True, text=True, check=True)
+
+
+def test_content_show(env_setup):
+    env, root, _ = env_setup
+    r = run([sys.executable, "main.py", "content", "show", "rule/attack.shortsword"], env, root)
+    assert "Shortsword" in r.stdout
+
+    r2 = run([sys.executable, "main.py", "content", "show", "monster/goblin"], env, root)
+    data = json.loads(r2.stdout)
+    assert data.get("hp") == 7

--- a/tests/phase7/test_manifest_incremental_all_types.py
+++ b/tests/phase7/test_manifest_incremental_all_types.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+import json
+import re
+
+
+def run(cmd, env, cwd):
+    return subprocess.run(cmd, env=env, cwd=cwd, capture_output=True, text=True, check=True)
+
+
+def test_manifest_incremental_all_types(env_setup):
+    env, root, data_dir = env_setup
+    first = run([sys.executable, "main.py", "content", "reload"], env, root)
+    idx1 = re.search(r"idx=([0-9a-f]{7})", first.stdout).group(1)
+
+    mfile = data_dir / "monsters.json"
+    monsters = json.loads(mfile.read_text())
+    monsters[0]["hp"] = 8
+    mfile.write_text(json.dumps(monsters))
+
+    second = run([sys.executable, "main.py", "content", "reload"], env, root)
+    upd = re.search(r"~(\d+)", second.stdout).group(1)
+    idx2 = re.search(r"idx=([0-9a-f]{7})", second.stdout).group(1)
+    assert upd == "1"
+    assert idx1 != idx2

--- a/tests/phase7/test_precedence_crosspacks.py
+++ b/tests/phase7/test_precedence_crosspacks.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+import json
+
+
+def run(cmd, env, cwd):
+    return subprocess.run(cmd, env=env, cwd=cwd, capture_output=True, text=True, check=True)
+
+
+def test_precedence_crosspacks(env_setup, tmp_path):
+    env, root, _ = env_setup
+    pack1 = tmp_path / "pack1"
+    pack1.mkdir()
+    (pack1 / "pack.json").write_text(json.dumps({"name": "P1", "version": "1"}))
+    (pack1 / "monsters").mkdir()
+    (pack1 / "monsters" / "goblin.json").write_text(json.dumps({"name": "Goblin", "hp": 5}))
+
+    pack2 = tmp_path / "pack2"
+    pack2.mkdir()
+    (pack2 / "pack.json").write_text(json.dumps({"name": "P2", "version": "1"}))
+    (pack2 / "monsters").mkdir()
+    (pack2 / "monsters" / "goblin.json").write_text(json.dumps({"name": "Goblin", "hp": 15}))
+
+    res = run(
+        [
+            sys.executable,
+            "main.py",
+            "content",
+            "reload",
+            "--packs",
+            f"{pack1},{pack2}",
+        ],
+        env,
+        root,
+    )
+    assert res.stdout.lower().count("conflict for monster/goblin") == 1
+
+    show = run([sys.executable, "main.py", "content", "show", "monster/goblin"], env, root)
+    payload = json.loads(show.stdout)
+    assert payload.get("hp") == 15


### PR DESCRIPTION
## Summary
- add unified content indexer and metadata manifest
- expose new `content` CLI for listing, showing and reloading docs
- keep `rules` commands as shims over the unified system

## Testing
- `pytest`
- `pre-commit run --files README.md grimbrain/rules/cli.py grimbrain/rules/resolver.py main.py data/monsters.json grimbrain/content/cli.py grimbrain/indexing/content_index.py tests/phase7/conftest.py tests/phase7/test_content_list_filters.py tests/phase7/test_content_show.py tests/phase7/test_manifest_incremental_all_types.py tests/phase7/test_precedence_crosspacks.py` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a25a0ae6588327bdff391670571b22