### PR TITLE
Implement death and dying state machine

### DIFF
--- a/grimbrain/engine/state.py
+++ b/grimbrain/engine/state.py
@@ -1,0 +1,22 @@
+"""State helper functions for death and dying."""
+from __future__ import annotations
+
+
+def set_dying(actor: dict) -> None:
+    actor["dying"] = True
+    actor["stable"] = False
+
+
+def set_stable(actor: dict) -> None:
+    actor["dying"] = False
+    actor["stable"] = True
+
+
+def clear_death_saves(actor: dict) -> None:
+    actor["death_failures"] = 0
+
+
+def add_death_failure(actor: dict, n: int = 1) -> None:
+    actor["death_failures"] = actor.get("death_failures", 0) + n
+    if actor["death_failures"] >= 3:
+        actor["dead"] = True

--- a/grimbrain/rules/evaluator.py
+++ b/grimbrain/rules/evaluator.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Set, Tuple
 
 from grimbrain.engine import dice
+from grimbrain.engine.state import (
+    set_dying,
+    set_stable,
+    clear_death_saves,
+    add_death_failure,
+)
 
 
 def _format_expr(expr: str, ctx: Dict[str, Any]) -> str:
@@ -31,18 +37,35 @@ class Evaluator:
     def apply(self, rule: Dict[str, Any], ctx: Dict[str, Any]) -> List[str]:
         logs: List[str] = []
         effects = rule.get("effects", [])
+        touched: Set[int] = set()
+        start_hp: Dict[int, int] = {}
+        dmg_info: Dict[int, Tuple[int, bool]] = {}
         for eff in effects:
             op = eff.get("op")
             target_name = eff.get("target", "target")
             tgt = ctx.get(target_name)
+            if tgt is not None:
+                tid = id(tgt)
+                touched.add(tid)
+                start_hp.setdefault(tid, tgt.get("hp", 0))
             if op == "damage" and tgt is not None:
                 amount = eval_formula(str(eff.get("amount", 0)), ctx)
                 tgt["hp"] = tgt.get("hp", 0) - amount
                 logs.append(f"{tgt['name']} takes {amount} damage")
+                is_crit = "critical" in eff.get("tags", [])
+                taken, crit = dmg_info.get(tid, (0, False))
+                dmg_info[tid] = (taken + amount, crit or is_crit)
             elif op == "heal" and tgt is not None:
                 amount = eval_formula(str(eff.get("amount", 0)), ctx)
                 tgt["hp"] = tgt.get("hp", 0) + amount
                 logs.append(f"{tgt['name']} heals {amount}")
+            elif op == "clear_death_saves" and tgt is not None:
+                clear_death_saves(tgt)
+            elif op == "set_stable" and tgt is not None:
+                set_stable(tgt)
+                logs.append(f"{tgt['name']} is stable at 0 HP.")
+            elif op == "set_dying" and tgt is not None:
+                set_dying(tgt)
             elif op == "tag_add" and tgt is not None:
                 tag = eff.get("tag")
                 tags = tgt.setdefault("tags", set())
@@ -56,4 +79,37 @@ class Evaluator:
             elif op == "log":
                 tmpl = eff.get("template", "")
                 logs.append(tmpl.format(**ctx))
+
+        for tid in touched:
+            # find actor by id from ctx
+            actor = next(v for v in ctx.values() if isinstance(v, dict) and id(v) == tid)
+            start = start_hp.get(tid, actor.get("hp", 0))
+            end = actor.get("hp", 0)
+            dmg, crit = dmg_info.get(tid, (0, False))
+            if start > 0 and end <= 0:
+                actor["hp"] = 0
+                set_dying(actor)
+                logs.append(f"{actor['name']} drops to 0 HP and is dying.")
+            elif start <= 0 and dmg > 0:
+                set_dying(actor)
+                actor["stable"] = False
+                fails = 2 if crit else 1
+                add_death_failure(actor, fails)
+                if crit:
+                    logs.append(
+                        f"Critical hit! {actor['name']} fails two death saves ({actor.get('death_failures',0)}/3)."
+                    )
+                else:
+                    logs.append(
+                        f"{actor['name']} takes damage while at 0 HP and fails a death save ({actor.get('death_failures',0)}/3)."
+                    )
+                if actor.get("dead"):
+                    logs.append(f"{actor['name']} dies.")
+            if start <= 0 and end > 0:
+                clear_death_saves(actor)
+                actor["dying"] = False
+                actor["stable"] = False
+                logs.append(
+                    f"{actor['name']} recovers to {actor.get('hp',0)} HP and is no longer dying."
+                )
         return logs

--- a/rules/custom/heal.json
+++ b/rules/custom/heal.json
@@ -5,7 +5,8 @@
   "cli_verb": "heal",
   "targets": ["target"],
   "effects": [
-    {"op": "heal", "target": "target", "amount": "1"}
+    {"op": "heal", "target": "target", "amount": "1"},
+    {"op": "clear_death_saves", "target": "target"}
   ],
   "log_templates": {}
 }

--- a/rules/custom/stabilize.json
+++ b/rules/custom/stabilize.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "stabilize",
+  "kind": "action",
+  "cli_verb": "stabilize",
+  "targets": ["target"],
+  "effects": [
+    {"op":"set_stable","target":"target"},
+    {"op":"clear_death_saves","target":"target"}
+  ],
+  "log_templates": {
+    "apply": "{actor.name} stabilizes {target.name} at 0 HP"
+  }
+}

--- a/tests/phase7/test_death_flow.py
+++ b/tests/phase7/test_death_flow.py
@@ -1,0 +1,76 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from grimbrain.rules.evaluator import Evaluator
+
+
+def test_drop_to_zero_enters_dying():
+    eva = Evaluator()
+    actor = {"name": "Hero", "hp": 3}
+    rule = {"effects": [{"op": "damage", "target": "target", "amount": "5"}]}
+    logs = eva.apply(rule, {"target": actor})
+    assert actor["hp"] == 0
+    assert actor.get("dying")
+    assert not actor.get("stable")
+    assert any("drops to 0 HP and is dying" in l for l in logs)
+
+
+def test_stable_then_damage_fails_one():
+    eva = Evaluator()
+    actor = {"name": "Hero", "hp": 0}
+    stabilize = {
+        "effects": [
+            {"op": "set_stable", "target": "target"},
+            {"op": "clear_death_saves", "target": "target"},
+        ]
+    }
+    eva.apply(stabilize, {"target": actor})
+    dmg_rule = {"effects": [{"op": "damage", "target": "target", "amount": "1"}]}
+    logs = eva.apply(dmg_rule, {"target": actor})
+    assert actor.get("death_failures") == 1
+    assert actor.get("dying") and not actor.get("stable")
+    assert any("fails a death save (1/3)" in l for l in logs)
+
+
+def test_critical_at_zero_fails_two():
+    eva = Evaluator()
+    actor = {"name": "Hero", "hp": 0}
+    stabilize = {
+        "effects": [
+            {"op": "set_stable", "target": "target"},
+            {"op": "clear_death_saves", "target": "target"},
+        ]
+    }
+    eva.apply(stabilize, {"target": actor})
+    dmg_rule = {
+        "effects": [
+            {"op": "damage", "target": "target", "amount": "1", "tags": ["critical"]}
+        ]
+    }
+    logs = eva.apply(dmg_rule, {"target": actor})
+    assert actor.get("death_failures") == 2
+    assert any("Critical hit!" in l for l in logs)
+
+
+def test_heal_clears_death_saves():
+    eva = Evaluator()
+    actor = {"name": "Hero", "hp": 0, "death_failures": 1, "dying": True}
+    heal_rule = {"effects": [{"op": "heal", "target": "target", "amount": "5"}]}
+    logs = eva.apply(heal_rule, {"target": actor})
+    assert actor["hp"] > 0
+    assert actor.get("death_failures") == 0
+    assert not actor.get("dying") and not actor.get("stable")
+    assert any("no longer dying" in l for l in logs)
+
+
+def test_three_failures_die():
+    eva = Evaluator()
+    actor = {"name": "Hero", "hp": 0, "dying": True}
+    dmg_rule = {"effects": [{"op": "damage", "target": "target", "amount": "1"}]}
+    for _ in range(2):
+        eva.apply(dmg_rule, {"target": actor})
+    logs = eva.apply(dmg_rule, {"target": actor})
+    assert actor.get("dead")
+    assert any("dies." in l for l in logs)


### PR DESCRIPTION
## Summary
- add state helpers and evaluator logic for dying, stable, and death saves
- support new set_stable and set_dying operations and clear death saves on heal
- document and test stabilize rule and death save flows

## Testing
- `pytest tests/phase7/test_death_flow.py -q`
- `pytest -q`
- `GB_ENGINE="data" GB_RULES_DIR="rules" GB_CHROMA_DIR=".chroma" python -m grimbrain.rules.index --rules rules --out .chroma`
- `GB_ENGINE="data" GB_RULES_DIR="rules" GB_CHROMA_DIR=".chroma" python main.py content list --type rule | grep -i stabilize`
- `GB_ENGINE="data" GB_RULES_DIR="rules" GB_CHROMA_DIR=".chroma" python main.py rules show stabilize`


------
https://chatgpt.com/codex/tasks/task_e_68a3cf2934cc832788a019d199d642e5