### PR TITLE
Fix healing logic for actors lacking max_hp

### DIFF
--- a/grimbrain/rules/evaluator.py
+++ b/grimbrain/rules/evaluator.py
@@ -89,10 +89,18 @@ class Evaluator:
             start = start_hp.get(tid, actor.get("hp", 0))
             end = actor.get("hp", 0)
             dmg, crit = dmg_info.get(tid, (0, False))
-            max_hp = actor.get("max_hp", start)
-            actor["hp"] = max(min(end, max_hp), -max_hp)
-            end = actor["hp"]
-            if instant_death_enabled() and start > 0 and start - dmg <= -max_hp:
+            max_hp = actor.get("max_hp")
+            if max_hp is not None:
+                actor["hp"] = max(min(end, max_hp), -max_hp)
+                end = actor["hp"]
+            else:
+                actor["hp"] = end
+            if (
+                instant_death_enabled()
+                and max_hp is not None
+                and start > 0
+                and start - dmg <= -max_hp
+            ):
                 actor["hp"] = 0
                 actor["dead"] = True
                 actor["dying"] = False


### PR DESCRIPTION
## Summary
- avoid clamping HP to zero when actors without `max_hp` are healed
- guard instant-death check when `max_hp` absent

## Testing
- `pytest tests/phase7/test_death_flow.py::test_heal_clears_death_saves -q`
- `pytest tests/phase7/test_death_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a472f38b4c8327947d9653fef911bb