### PR TITLE
Route play JSON mode messages to stderr

### DIFF
--- a/tests/phase7/test_play_json_only.py
+++ b/tests/phase7/test_play_json_only.py
@@ -1,0 +1,26 @@
+import json
+import subprocess
+import sys
+
+
+def run_play(args):
+    cmd = [sys.executable, "main.py", "play"] + args
+    return subprocess.run(cmd, capture_output=True, text=True, input="")
+
+
+def test_json_only_stdout():
+    res = run_play([
+        "--pc", "tests/fixtures/pc_basic.json",
+        "--encounter", "goblin",
+        "--seed", "7",
+        "--json",
+        "--quiet",
+    ])
+    lines = [l for l in res.stdout.splitlines() if l]
+    assert lines, res.stdout
+    assert all(l.startswith("{") for l in lines), res.stdout
+    last = json.loads(lines[-1])
+    assert last.get("event") == "summary"
+    assert "Indexed" not in res.stdout
+    assert "Conflict:" not in res.stdout
+    assert ("Indexed" in res.stderr) or ("Conflict:" in res.stderr)


### PR DESCRIPTION
## Summary
- ensure play's JSON mode sends human messages (indexing, conflicts, summary) to stderr and emits a JSON summary event
- hide prompts/logs from stdout so JSON mode outputs one JSON object per line
- add regression test validating JSON-only stdout

## Testing
- `pytest tests/phase7/test_play_json_only.py -q`
- `pytest tests/phase7/test_play_cli.py::test_json_output -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4cad5060c8327b65412cbe0f4abf0