### PR TITLE
Ensure play --json only emits JSON on stdout

### DIFF
--- a/grimbrain/play_cli.py
+++ b/grimbrain/play_cli.py
@@ -6,7 +6,8 @@ import os
 import random
 import re
 import sys
-import contextlib
+import io
+from contextlib import redirect_stdout
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
@@ -94,8 +95,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.packs:
         reload_args += ["--packs", args.packs]
     if args.json:
-        with contextlib.redirect_stdout(sys.stderr):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
             content_cli.main(reload_args)
+        sys.stderr.write(buf.getvalue())
     else:
         content_cli.main(reload_args)
 


### PR DESCRIPTION
## Summary
- Capture content reload output and emit it to stderr when `play --json` is used
- Keep human log messages on stderr so stdout remains pure JSON

## Testing
- `pytest tests/phase7/test_play_json_only.py::test_json_only_stdout -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d729eb0c832785e78d1486fa193a