### PR TITLE
Ensure deterministic verb suggestion ordering

### DIFF
--- a/grimbrain/rules/resolver.py
+++ b/grimbrain/rules/resolver.py
@@ -208,7 +208,7 @@ class RuleResolver:
             sub = 1 if query in alias else 0
             ratio = difflib.SequenceMatcher(None, query, alias).ratio()
             scored.append((start, sub, ratio, canon))
-        scored.sort(key=lambda x: (-x[0], -x[1], -x[2]))
+        scored.sort(key=lambda x: (-x[0], -x[1], -x[2], x[3]))
         suggestions: List[str] = []
         seen: Set[str] = set()
         for _, _, _, canon in scored:


### PR DESCRIPTION
## Summary
- Ensure verb suggestions are sorted with a canonical name tie-breaker
- Prevent default verbs like heal from being omitted when suggestions are truncated

## Testing
- `pytest tests/phase7/test_verb_suggestions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a629e623c4832784b50491229c2790