### PR TITLE
Add play helper wrapper

### DIFF
--- a/grimbrain/play.py
+++ b/grimbrain/play.py
@@ -1,0 +1,20 @@
+def run_play(pc, encounter=None, seed=None, script=None, json_mode=False, summary_only=False):
+    """Wrapper around the CLI play entry point.
+
+    This helper allows callers to invoke the play CLI directly from Python code
+    while still supporting the ``--json`` and ``--summary-only`` flags.
+    """
+    from . import play_cli
+
+    args = ["--pc", pc]
+    if encounter:
+        args.extend(["--encounter", str(encounter)])
+    if seed is not None:
+        args.extend(["--seed", str(seed)])
+    if script:
+        args.extend(["--script", script])
+    if json_mode:
+        args.append("--json")
+    if summary_only:
+        args.append("--summary-only")
+    return play_cli.main(args)


### PR DESCRIPTION
## Summary
- Provide a `grimbrain.play.run_play` helper delegating to the CLI while handling `--json` and `--summary-only` flags

## Testing
- `pytest -q tests/test_golden_play.py tests/test_rules_doctor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a876b459f88327bb8eb3b779d001f6