### PR TITLE
Add timed effect pack rules and fix reload paths

### DIFF
--- a/grimbrain/effects.py
+++ b/grimbrain/effects.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+"""Very small timed effect engine used by the ``play`` CLI.
+
+The engine keeps all state in a simple mapping supplied at construction time
+so that callers can persist it inside their own data structures.  Each effect
+is tracked per owner and is evaluated at either the start or the end of a
+turn.  Effects can apply deterministic damage (positive) or healing
+(negative) and may add or remove tags on the affected actor while active.
+
+The engine itself is intentionally tiny – it only supports the features that
+the tests exercise.  It is sufficient for demonstrating how timed effects can
+be scheduled from rules and processed by the game loop in a deterministic
+fashion.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class TimedEffect:
+    """Description of an effect with a fixed duration."""
+
+    id: str
+    owner_id: str  # actor that the effect is applied to
+    source_rule: str
+    timing: str  # ``start_of_turn`` or ``end_of_turn``
+    duration_rounds: int
+    remaining_rounds: int
+    tag_add: Optional[str] = None
+    tag_remove_on_expire: Optional[str] = None
+    fixed_damage: Optional[int] = None  # positive=damage, negative=heal
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+class EffectEngine:
+    """Minimal in-memory effect tracker."""
+
+    def __init__(self, state: Dict[str, Any]):
+        self.state = state
+        # Map of ``actor_id`` -> list of serialized effects
+        self.state.setdefault("timed_effects", {})
+
+    # ------------------------------------------------------------------
+    # effect management helpers
+    def add_effect(self, effect: TimedEffect) -> Dict[str, Any]:
+        """Register ``effect`` and return an ``effect_started`` event."""
+
+        bucket = self.state["timed_effects"].setdefault(effect.owner_id, [])
+        bucket.append(effect.__dict__.copy())
+        return {
+            "kind": "effect_started",
+            "owner": effect.owner_id,
+            "effect_id": effect.id,
+            "rule": effect.source_rule,
+            "remaining": effect.remaining_rounds,
+        }
+
+    # ------------------------------------------------------------------
+    def _iter_effects(self, actor_id: str):
+        for eff in self.state["timed_effects"].get(actor_id, []):
+            yield eff
+
+    def _prune(self, actor_id: str) -> None:
+        self.state["timed_effects"][actor_id] = [
+            e for e in self.state["timed_effects"].get(actor_id, [])
+            if e["remaining_rounds"] > 0
+        ]
+
+    # ------------------------------------------------------------------
+    def on_turn_hook(
+        self,
+        actor_id: str,
+        hook: str,
+        apply_damage_cb,
+        add_tag_cb,
+        remove_tag_cb,
+    ) -> List[Dict[str, Any]]:
+        """Process effects for ``actor_id`` at the specified hook.
+
+        ``hook`` must be ``"start_of_turn"`` or ``"end_of_turn"``.  The
+        callbacks are invoked for deterministic damage/healing and for tag
+        mutations.  The method returns a list of JSON-style events describing
+        what happened.
+        """
+
+        events: List[Dict[str, Any]] = []
+        any_changed = False
+        for eff in list(self._iter_effects(actor_id)):
+            if eff.get("timing") != hook:
+                continue
+            if eff.get("fixed_damage"):
+                apply_damage_cb(actor_id, int(eff["fixed_damage"]))
+                events.append(
+                    {
+                        "kind": "effect_tick",
+                        "owner": actor_id,
+                        "effect_id": eff["id"],
+                        "delta_hp": -int(eff["fixed_damage"]),
+                        "remaining": eff["remaining_rounds"],
+                    }
+                )
+            eff["remaining_rounds"] -= 1
+            any_changed = True
+            if eff["remaining_rounds"] <= 0:
+                if eff.get("tag_remove_on_expire"):
+                    remove_tag_cb(actor_id, eff["tag_remove_on_expire"])
+                events.append(
+                    {
+                        "kind": "effect_expired",
+                        "owner": actor_id,
+                        "effect_id": eff["id"],
+                    }
+                )
+        if any_changed:
+            self._prune(actor_id)
+        return events
+

--- a/grimbrain/play_cli.py
+++ b/grimbrain/play_cli.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 import subprocess
 
+from grimbrain.effects import EffectEngine
+
 from grimbrain.content import cli as content_cli
 from grimbrain.content.ids import canonicalize_id
 from grimbrain.rules.resolver import RuleResolver
@@ -67,6 +69,7 @@ def _load_party(path: Path) -> List[Dict[str, object]]:
         pc.setdefault("skills", [])
         pc.setdefault("prof", pc.get("prof_bonus", pc.get("prof", 0)))
         pc.setdefault("side", "party")
+        pc.setdefault("tags", set())
         res.append(pc)
     return res
 
@@ -132,7 +135,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             idx.extend(["--packs", pth])
         subprocess.run(idx, check=True, stdout=sys.stderr, stderr=sys.stderr)
         # Reload via module so we don't depend on repo layout
-        subprocess.run([sys.executable, "-m", "grimbrain.rules.cli", "reload"],
+        subprocess.run([sys.executable, "-m", "grimbrain.rules.cli", "rules", "reload", "--packs", ",".join(packs)],
                        check=True, stdout=sys.stderr, stderr=sys.stderr)
 
     def log(*a, **k):
@@ -167,6 +170,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             "skills": [],
             "prof": 0,
             "side": "monsters",
+            "tags": set(),
         })
 
     combatants = party + monsters
@@ -178,6 +182,39 @@ def main(argv: Optional[List[str]] = None) -> int:
     if msg:
         log(msg)
     evaluator = Evaluator()
+
+    effects_state: Dict[str, object] = {}
+    effects = EffectEngine(effects_state)
+
+    def apply_fixed_damage(actor_id: str, amount: int) -> None:
+        tgt = name_map.get(actor_id.lower())
+        if not tgt:
+            return
+        tgt.setdefault("hp", 0)
+        tgt["hp"] = tgt.get("hp", 0) - amount
+
+    def add_tag(actor_id: str, tag: str) -> None:
+        tgt = name_map.get(actor_id.lower())
+        if tgt is not None:
+            tgt.setdefault("tags", set()).add(tag)
+
+    def remove_tag(actor_id: str, tag: str) -> None:
+        tgt = name_map.get(actor_id.lower())
+        if tgt is not None:
+            tgt.setdefault("tags", set()).discard(tag)
+
+    def emit_events(ev_list: List[Dict[str, object]]) -> None:
+        for ev in ev_list:
+            if args.json:
+                print(json.dumps(ev))
+            else:
+                kind = ev.get("kind")
+                if kind == "effect_tick":
+                    log(f"{ev['owner']} takes {-ev.get('delta_hp',0)} ongoing damage")
+                elif kind == "effect_expired":
+                    log(f"Effect on {ev['owner']} ends")
+                elif kind == "effect_started":
+                    log(f"Effect on {ev['owner']} begins")
 
     def state_line() -> str:
         hero = party[0] if party else {"name": "hero", "hp": 0}
@@ -219,7 +256,9 @@ def main(argv: Optional[List[str]] = None) -> int:
             "prof": actor.get("prof", 0),
             "seed": rng.randint(1, 10 ** 6),
         }
-        logs = evaluator.apply(use_rule, ctx)
+        events: List[Dict[str, object]] = []
+        logs = evaluator.apply(use_rule, ctx, engine=effects, events=events)
+        emit_events(events)
         if args.summary_only:
             return
         if args.json:
@@ -259,8 +298,27 @@ def main(argv: Optional[List[str]] = None) -> int:
             lines = _iter()
 
     rounds = 0
+    actor_name = party[0]["name"] if party else ""
     for cmd in lines:
+        emit_events(
+            effects.on_turn_hook(
+                actor_name,
+                "start_of_turn",
+                apply_fixed_damage,
+                add_tag,
+                remove_tag,
+            )
+        )
         run_command(cmd)
+        emit_events(
+            effects.on_turn_hook(
+                actor_name,
+                "end_of_turn",
+                apply_fixed_damage,
+                add_tag,
+                remove_tag,
+            )
+        )
         rounds += 1
 
     alive = [c["name"] for c in combatants if c.get("hp", 0) > 0 and not c.get("dead")]

--- a/packs/test_effects/pack.json
+++ b/packs/test_effects/pack.json
@@ -1,0 +1,5 @@
+{
+  "name": "test_effects",
+  "version": "1",
+  "license": "CC0"
+}

--- a/packs/test_effects/rules/ignite.json
+++ b/packs/test_effects/rules/ignite.json
@@ -1,0 +1,11 @@
+{
+  "id": "ignite",
+  "kind": "action",
+  "cli_verb": "ignite",
+  "targets": ["ally_or_self"],
+  "effects": [
+    { "duration_rounds": 3, "timing": "start_of_turn", "fixed_damage": 2, "tag_add": "burning" }
+  ],
+  "log_templates": { "start": "{actor.name} ignites {target.name} (burning)", "apply": "{target.name} starts burning" }
+}
+

--- a/packs/test_effects/rules/quench.json
+++ b/packs/test_effects/rules/quench.json
@@ -1,0 +1,11 @@
+{
+  "id": "quench",
+  "kind": "action",
+  "cli_verb": "quench",
+  "targets": ["ally_or_self"],
+  "effects": [
+    { "op": "tag_remove", "target": "target", "tag": "burning" }
+  ],
+  "log_templates": { "start": "{actor.name} quenches {target.name}", "apply": "{target.name} is no longer burning" }
+}
+

--- a/rules/custom/ignite.json
+++ b/rules/custom/ignite.json
@@ -1,0 +1,11 @@
+{
+  "id": "ignite",
+  "kind": "action",
+  "cli_verb": "ignite",
+  "targets": ["ally_or_self"],
+  "effects": [
+    { "duration_rounds": 3, "timing": "start_of_turn", "fixed_damage": 2, "tag_add": "burning" }
+  ],
+  "log_templates": { "start": "{actor.name} ignites {target.name} (burning)", "apply": "{target.name} starts burning" }
+}
+

--- a/rules/custom/quench.json
+++ b/rules/custom/quench.json
@@ -1,0 +1,11 @@
+{
+  "id": "quench",
+  "kind": "action",
+  "cli_verb": "quench",
+  "targets": ["ally_or_self"],
+  "effects": [
+    { "op": "tag_remove", "target": "target", "tag": "burning" }
+  ],
+  "log_templates": { "start": "{actor.name} quenches {target.name}", "apply": "{target.name} is no longer burning" }
+}
+

--- a/tests/golden/burning_pretty.golden
+++ b/tests/golden/burning_pretty.golden
@@ -1,0 +1,13 @@
+Conflict: rule/attack.shortbow -> keeping generated, ignoring legacy-data
+Conflict: rule/attack.shortsword -> keeping generated, ignoring legacy-data
+Indexed 11 docs (+1 / ~0 / -0) (by_type={'rule': 10, 'monster': 1}, packs={'generated': 2, 'legacy-data': 1, 'custom': 8}, idx=fb39430).
+Warmed resolver cache for 0 docs in 0.00s.
+Effect on Hero begins
+Hero ignites Hero (burning)
+Hero starts burning
+HP: Hero=10; monsters=[Goblin:7]
+Hero takes 2 ongoing damage
+Hero takes 2 ongoing damage
+Hero takes 2 ongoing damage
+Effect on Hero ends
+Summary: rounds=4; alive=['Hero', 'Goblin']; dead=[]; stable=[]

--- a/tests/scripts/burning.txt
+++ b/tests/scripts/burning.txt
@@ -1,0 +1,4 @@
+ignite Hero
+
+
+

--- a/tests/test_effects_engine.py
+++ b/tests/test_effects_engine.py
@@ -1,0 +1,54 @@
+import os, sys, subprocess, pathlib, json
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MAIN = ROOT / "main.py"
+
+
+def run_play(script, seed=7, json_mode=True, packs="packs/test_effects"):
+    env = os.environ.copy()
+    env.setdefault("GB_ENGINE", "data")
+    env.setdefault("GB_RULES_DIR", "rules")
+    env.setdefault("GB_CHROMA_DIR", ".chroma")
+    env.setdefault("GB_RESOLVER_WARM_COUNT", "0")
+    if packs:
+        idx = [
+            sys.executable,
+            "-m",
+            "grimbrain.rules.index",
+            "--rules",
+            "rules",
+            "--out",
+            ".chroma",
+            "--packs",
+            packs,
+        ]
+        subprocess.run(idx, cwd=str(ROOT), check=True, capture_output=True, text=True, env=env)
+        subprocess.run([sys.executable, "-m", "grimbrain.rules.cli", "rules", "reload", "--packs", packs], cwd=str(ROOT), check=True, capture_output=True, text=True, env=env)
+    cmd = [
+        sys.executable,
+        str(MAIN),
+        "play",
+        "--pc",
+        "tests/fixtures/pc_basic.json",
+        "--encounter",
+        "goblin",
+        "--seed",
+        str(seed),
+        "--script",
+        f"tests/scripts/{script}",
+    ]
+    if json_mode:
+        cmd.append("--json")
+    cp = subprocess.run(cmd, cwd=str(ROOT), capture_output=True, text=True, env=env)
+    return cp.returncode, cp.stdout, cp.stderr
+
+
+def test_ignite_ticks_and_expires_json():
+    code, out, err = run_play("burning.txt")
+    assert code == 0
+    lines = [json.loads(l) for l in out.splitlines() if l.strip()]
+    kinds = [l.get("kind") for l in lines]
+    assert "effect_started" in kinds
+    assert kinds.count("effect_tick") >= 2
+    assert "effect_expired" in kinds
+

--- a/tests/test_golden_effects.py
+++ b/tests/test_golden_effects.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import subprocess
+import pathlib
+import difflib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MAIN = ROOT / "main.py"
+GOLDEN = ROOT / "tests" / "golden"
+
+
+def test_burning_pretty_golden():
+    env = os.environ.copy()
+    env.setdefault("GB_ENGINE", "data")
+    env.setdefault("GB_RULES_DIR", "rules")
+    env.setdefault("GB_CHROMA_DIR", ".chroma")
+    env.setdefault("GB_RESOLVER_WARM_COUNT", "0")
+    idx = [
+        sys.executable,
+        "-m",
+        "grimbrain.rules.index",
+        "--rules",
+        "rules",
+        "--out",
+        ".chroma",
+        "--packs",
+        "packs/test_effects",
+    ]
+    subprocess.run(idx, cwd=str(ROOT), check=True, env=env, capture_output=True, text=True)
+    subprocess.run([sys.executable, "-m", "grimbrain.rules.cli", "rules", "reload", "--packs", "packs/test_effects"], cwd=str(ROOT), check=True, env=env, capture_output=True, text=True)
+    cmd = [
+        sys.executable,
+        str(MAIN),
+        "play",
+        "--pc",
+        "tests/fixtures/pc_basic.json",
+        "--encounter",
+        "goblin",
+        "--seed",
+        "7",
+        "--script",
+        "tests/scripts/burning.txt",
+    ]
+    cp = subprocess.run(cmd, cwd=str(ROOT), capture_output=True, text=True, env=env)
+    assert cp.returncode == 0
+    got = cp.stdout
+    want = (GOLDEN / "burning_pretty.golden").read_text(encoding="utf-8")
+    if got != want:
+        diff = "\n".join(
+            difflib.unified_diff(
+                want.splitlines(), got.splitlines(),
+                fromfile="burning_pretty.golden", tofile="got", lineterm="",
+            )
+        )
+        raise AssertionError(f"Golden mismatch:\n{diff}")
+


### PR DESCRIPTION
## Summary
- ensure play CLI reloads packs via `rules reload --packs`
- restructure test effect pack with manifest and updated test scripts
- seed burning effect golden and run effect engine tests

## Testing
- `pytest -q tests/test_effects_engine.py`
- `pytest -q tests/test_golden_effects.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b36b00a083278f82880be2ab9617