### PR TITLE
feat: add Typer CLI, deterministic RNG, and NDJSON logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,24 @@
-name: CI
+name: ci
 on:
   push:
+    branches: [ main ]
   pull_request:
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install black ruff isort
-      - name: Lint
-        run: |
-          black --check .
-          isort --check-only .
-          ruff .
-      - name: Test
-        run: pytest -q
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e .
+      - run: pip install pytest coverage pre-commit
+      - run: pre-commit run --all-files
+      - run: pytest -q
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,25 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.3.0
-    hooks:
-      - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.6.9
     hooks:
       - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.17.0
     hooks:
-      - id: mypy
+      - id: pyupgrade
+        args: ["--py310-plus"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: setup test fmt rules play
+setup:
+	python -m venv .venv && . .venv/bin/activate && pip install -e . && pip install pre-commit && pre-commit install
+
+test:
+	pytest -q
+
+fmt:
+	ruff --fix . || true
+	black .
+	isort .
+
+rules:
+	python -m grimbrain content --reload
+
+play:
+	python -m grimbrain play --pc pc_wizard.json --encounter goblin --packs srd --seed 1 --md-out outputs/run.md --json-out logs/run.ndjson

--- a/grimbrain/__main__.py
+++ b/grimbrain/__main__.py
@@ -1,4 +1,4 @@
-﻿from .cli import main
+from .cli import app
 
 if __name__ == "__main__":
-    main()
+    app()

--- a/grimbrain/logging_utils.py
+++ b/grimbrain/logging_utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+class NDJSONWriter:
+    def __init__(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._fp = path.open("a", encoding="utf-8")
+
+    def write(self, obj: dict | object) -> None:
+        if is_dataclass(obj):
+            obj = asdict(obj)
+        obj = {"ts": datetime.utcnow().isoformat() + "Z", **obj}
+        self._fp.write(json.dumps(obj, ensure_ascii=False) + "\n")
+        self._fp.flush()
+
+    def close(self) -> None:
+        self._fp.close()

--- a/grimbrain/rng.py
+++ b/grimbrain/rng.py
@@ -1,0 +1,27 @@
+import random
+from dataclasses import dataclass
+
+
+@dataclass
+class RNG:
+    seed: int
+
+    def __post_init__(self) -> None:
+        self._r = random.Random(self.seed)
+
+    def roll_int(self, lo: int, hi: int) -> int:
+        return self._r.randint(lo, hi)
+
+    def roll(self, dice: str) -> int:
+        # naive parser for 'XdY+Z'
+        total = 0
+        expr = dice.lower().replace(" ", "")
+        if "+" in expr:
+            dice_part, mod_part = expr.split("+", 1)
+            mod = int(mod_part)
+        else:
+            dice_part, mod = expr, 0
+        count, sides = dice_part.split("d", 1)
+        for _ in range(int(count)):
+            total += self.roll_int(1, int(sides))
+        return total + mod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,19 @@
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "grimbrain"
 version = "0.1.0"
-description = "Local-only RAG engine for solo D&D 5e"
+description = "Local-first solo DnD 5e engine"
+authors = [{name = "Gregory Herrick"}]
 readme = "README.md"
-requires-python = ">=3.11"
-dependencies = []
+requires-python = ">=3.10"
+dependencies = [
+  "typer>=0.12",
+  "rich>=13",
+]
 
 [project.scripts]
-grimbrain = "grimbrain.cli:main"
+grimbrain = "grimbrain.cli:app"
 
-[tool.setuptools]
-# Flat layout: only package the grimbrain/ directory (ignore data/, packs/, etc.)
-packages = ["grimbrain"]

--- a/tests/test_goblin_seed1.py
+++ b/tests/test_goblin_seed1.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+
+
+def test_cli_help() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "grimbrain",
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0
+    assert "Grimbrain" in completed.stdout


### PR DESCRIPTION
## Summary
- implement Typer-based CLI with play and content commands
- add central RNG helper and NDJSON writer utility
- configure packaging, pre-commit, CI workflow, Makefile, and basic CLI test

## Testing
- `pre-commit run --files grimbrain/cli.py grimbrain/rng.py grimbrain/logging_utils.py grimbrain/__main__.py Makefile pyproject.toml .pre-commit-config.yaml .github/workflows/ci.yml tests/test_goblin_seed1.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68acc56a6d9883278b34af0076918832