### PR TITLE
Add schema validation, Pydantic models, and CLI validation

### DIFF
--- a/grimbrain/cli.py
+++ b/grimbrain/cli.py
@@ -7,10 +7,12 @@ from pathlib import Path
 from rich import box
 import typer
 import typer.rich_utils as tru
+from grimbrain.cli_validate import validate_app
 
 tru.Panel = partial(tru.Panel, box=box.ASCII)
 
 app = typer.Typer(no_args_is_help=True)
+app.add_typer(validate_app, name="validate")
 
 @app.callback()
 def main() -> None:

--- a/grimbrain/cli_validate.py
+++ b/grimbrain/cli_validate.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from grimbrain.validation import load_pc, load_campaign, PrettyError
+
+
+validate_app = typer.Typer(help="Validate Grimbrain data files")
+
+
+@validate_app.command()
+def pc(file: Path = typer.Argument(..., exists=True)):
+    """Validate a PC json file."""
+    try:
+        _ = load_pc(file)
+        typer.secho(f"OK: {file}", fg=typer.colors.GREEN)
+    except PrettyError as e:
+        typer.secho(f"ERR: {file}\n{e}", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+
+@validate_app.command()
+def campaign(file: Path = typer.Argument(..., exists=True)):
+    """Validate a campaign yaml file."""
+    try:
+        _ = load_campaign(file)
+        typer.secho(f"OK: {file}", fg=typer.colors.GREEN)
+    except PrettyError as e:
+        typer.secho(f"ERR: {file}\n{e}", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+
+__all__ = ["validate_app"]
+

--- a/grimbrain/models/__init__.py
+++ b/grimbrain/models/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import Any, Dict, List
 
+
 class NamedText(BaseModel):
     name: str
     text: str
@@ -17,6 +18,7 @@ class ActionStruct(BaseModel):
     hit_text: str
     damage_dice: str
     damage_type: str
+
 
 class MonsterSidecar(BaseModel):
     name: str
@@ -35,6 +37,7 @@ class MonsterSidecar(BaseModel):
     actions_struct: List[ActionStruct] = Field(default_factory=list)
     reactions: List[NamedText]
     provenance: List[str]
+
 
 class SpellSidecar(BaseModel):
     name: str
@@ -118,3 +121,15 @@ def dump_model(m: BaseModel) -> Dict[str, Any]:
     if hasattr(m, "model_dump"):
         return m.model_dump()
     return m.dict()
+
+
+__all__ = [
+    "NamedText",
+    "ActionStruct",
+    "MonsterSidecar",
+    "SpellSidecar",
+    "Attack",
+    "PC",
+    "dump_model",
+]
+

--- a/grimbrain/models/campaign.py
+++ b/grimbrain/models/campaign.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class Quest(BaseModel):
+    id: str
+    title: str
+    steps: List[str] = []
+
+
+class Campaign(BaseModel):
+    name: str = Field(min_length=1)
+    party: List[str]
+    packs: List[str] = []
+    quests: List[Quest] = []
+
+
+__all__ = ["Quest", "Campaign"]
+

--- a/grimbrain/models/pc.py
+++ b/grimbrain/models/pc.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, PositiveInt
+from typing import List, Optional, Dict
+
+
+class Abilities(BaseModel):
+    str: PositiveInt
+    dex: PositiveInt
+    con: PositiveInt
+    int: PositiveInt
+    wis: PositiveInt
+    cha: PositiveInt
+
+
+class Item(BaseModel):
+    name: str
+    qty: PositiveInt | None = 1
+    props: Dict[str, object] | None = None
+
+
+class PlayerCharacter(BaseModel):
+    name: str = Field(min_length=1)
+    class_: str = Field(alias="class", min_length=1)
+    subclass: Optional[str] = None
+    background: Optional[str] = None
+    race: Optional[str] = None
+    level: PositiveInt
+    proficiency_bonus: Optional[PositiveInt] = None
+    abilities: Abilities
+    ac: PositiveInt
+    max_hp: PositiveInt
+    current_hp: Optional[int] = None
+    inventory: List[Item] = []
+    spells: List[str] = []
+    notes: Optional[str] = None
+
+    class Config:
+        populate_by_name = True
+
+
+__all__ = ["PlayerCharacter", "Abilities", "Item"]
+

--- a/grimbrain/validation.py
+++ b/grimbrain/validation.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+import json
+import yaml
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
+
+from grimbrain.models.pc import PlayerCharacter
+from grimbrain.models.campaign import Campaign
+
+
+SCHEMA_DIR = Path(__file__).resolve().parent.parent / "schema"
+
+
+class PrettyError(Exception):
+    pass
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_yaml(path: Path) -> Any:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+_def_schemas = {
+    "pc": SCHEMA_DIR / "pc.schema.json",
+    "campaign": SCHEMA_DIR / "campaign.schema.json",
+}
+
+
+def _validate_jsonschema(obj: Any, schema_path: Path) -> None:
+    schema = _read_json(schema_path)
+    v = Draft202012Validator(schema)
+    errors = sorted(v.iter_errors(obj), key=lambda e: e.path)
+    if errors:
+        lines = []
+        for e in errors[:5]:
+            ptr = "/" + "/".join([str(p) for p in e.path])
+            lines.append(f"- {ptr or '/'}: {e.message}")
+        more = "" if len(errors) <= 5 else f" (+{len(errors)-5} more)"
+        raise PrettyError("JSON Schema validation failed:\n" + "\n".join(lines) + more)
+
+
+# Public API
+
+
+def load_pc(path: Path) -> PlayerCharacter:
+    data = _read_json(path)
+    _validate_jsonschema(data, _def_schemas["pc"])
+    try:
+        return PlayerCharacter.model_validate(data)
+    except ValidationError as e:
+        raise PrettyError(e.errors(include_url=False))
+
+
+def load_campaign(path: Path) -> Campaign:
+    data = _read_yaml(path)
+    _validate_jsonschema(data, _def_schemas["campaign"])
+    try:
+        return Campaign.model_validate(data)
+    except ValidationError as e:
+        raise PrettyError(e.errors(include_url=False))
+
+
+__all__ = ["load_pc", "load_campaign", "PrettyError"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ requires-python = ">=3.10"
 dependencies = [
   "typer>=0.12",
   "rich>=13",
+  "pydantic>=2.7",
+  "pyyaml>=6.0.2",
+  "jsonschema>=4.23",
 ]
 
 [project.scripts]

--- a/schema/campaign.schema.json
+++ b/schema/campaign.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grimbrain/schema/campaign.schema.json",
+  "title": "Campaign",
+  "type": "object",
+  "required": ["name", "party"],
+  "properties": {
+    "name": {"type": "string", "minLength": 1},
+    "party": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "packs": {"type": "array", "items": {"type": "string"}},
+    "quests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "title"],
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "steps": {"type": "array", "items": {"type": "string"}}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}
+

--- a/schema/pc.schema.json
+++ b/schema/pc.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grimbrain/schema/pc.schema.json",
+  "title": "PlayerCharacter",
+  "type": "object",
+  "required": ["name", "class", "level", "abilities", "max_hp", "ac"],
+  "properties": {
+    "name": {"type": "string", "minLength": 1},
+    "class": {"type": "string", "minLength": 1},
+    "subclass": {"type": "string"},
+    "background": {"type": "string"},
+    "race": {"type": "string"},
+    "level": {"type": "integer", "minimum": 1},
+    "proficiency_bonus": {"type": "integer", "minimum": 1},
+    "abilities": {
+      "type": "object",
+      "required": ["str", "dex", "con", "int", "wis", "cha"],
+      "properties": {
+        "str": {"type": "integer", "minimum": 1, "maximum": 30},
+        "dex": {"type": "integer", "minimum": 1, "maximum": 30},
+        "con": {"type": "integer", "minimum": 1, "maximum": 30},
+        "int": {"type": "integer", "minimum": 1, "maximum": 30},
+        "wis": {"type": "integer", "minimum": 1, "maximum": 30},
+        "cha": {"type": "integer", "minimum": 1, "maximum": 30}
+      },
+      "additionalProperties": false
+    },
+    "ac": {"type": "integer", "minimum": 1},
+    "max_hp": {"type": "integer", "minimum": 1},
+    "current_hp": {"type": "integer", "minimum": 0},
+    "inventory": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {"type": "string"},
+          "qty": {"type": "integer", "minimum": 1},
+          "props": {"type": "object"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "spells": {"type": "array", "items": {"type": "string"}},
+    "notes": {"type": "string"}
+  },
+  "additionalProperties": false
+}
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import json
+import textwrap
+
+import pytest
+
+from grimbrain.validation import load_pc, load_campaign, PrettyError
+
+
+def test_load_pc_ok(tmp_path: Path) -> None:
+    pc = {
+        "name": "Elora",
+        "class": "Wizard",
+        "level": 1,
+        "abilities": {"str": 8, "dex": 14, "con": 12, "int": 16, "wis": 10, "cha": 12},
+        "ac": 12,
+        "max_hp": 8,
+    }
+    p = tmp_path / "pc.json"
+    p.write_text(json.dumps(pc), encoding="utf-8")
+    obj = load_pc(p)
+    assert obj.name == "Elora" and obj.level == 1
+
+
+def test_load_pc_schema_error(tmp_path: Path) -> None:
+    bad = {"name": "NoAbilities", "class": "Wizard", "level": 1, "ac": 12, "max_hp": 8}
+    p = tmp_path / "pc.json"
+    p.write_text(json.dumps(bad), encoding="utf-8")
+    with pytest.raises(PrettyError):
+        load_pc(p)
+
+
+def test_load_campaign_ok(tmp_path: Path) -> None:
+    yml = textwrap.dedent(
+        """
+        name: Starter
+        party: [pc_wizard.json]
+        packs: [srd]
+        quests:
+          - id: q1
+            title: Prologue
+            steps: [wake up, find staff]
+        """
+    )
+    p = tmp_path / "campaign.yaml"
+    p.write_text(yml, encoding="utf-8")
+    obj = load_campaign(p)
+    assert obj.name == "Starter" and obj.party[0] == "pc_wizard.json"
+
+
+def test_load_campaign_schema_error(tmp_path: Path) -> None:
+    yml = "name: MissingParty"  # party required
+    p = tmp_path / "campaign.yaml"
+    p.write_text(yml, encoding="utf-8")
+    with pytest.raises(PrettyError):
+        load_campaign(p)
+


### PR DESCRIPTION
## Summary
- add JSON Schema for player characters and campaigns
- implement Pydantic models and loader with friendly JSON Schema validation
- expose `grimbrain validate` CLI commands for pc and campaign files

## Testing
- `pytest tests/test_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68adaba9c2848327b7638e038b394f1e