### PR TITLE
PR 5 — Phase 2 Kickoff: Character Model + Generator Stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ quests:
 }
 ```
 
+### Character quickstart
+
+Create a level‑1 Wizard:
+```bash
+grimbrain character create --name Elora --klass Wizard --race "High Elf" \
+  --background Sage --ac 12 --str 8 --dex 14 --con 12 --int 16 --wis 10 --cha 12 \
+  --out pc_wizard.json
+```
+Level to 3:
+```bash
+grimbrain character level pc_wizard.json --to 3
+```
+
 ## Python API
 ```python
 from grimbrain.retrieval.query_router import run_query

--- a/grimbrain/characters.py
+++ b/grimbrain/characters.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from grimbrain.models.pc import Abilities, PlayerCharacter, SpellSlots
+
+# Simple SRD baseline hit-die map
+HIT_DIE = {
+    "Barbarian": 12,
+    "Fighter": 10,
+    "Paladin": 10,
+    "Ranger": 10,
+    "Bard": 8,
+    "Cleric": 8,
+    "Druid": 8,
+    "Monk": 8,
+    "Rogue": 8,
+    "Warlock": 8,
+    "Sorcerer": 6,
+    "Wizard": 6,
+}
+
+# Wizard slots quick table (L1–L5 for example). Extend for full SRD later.
+WIZARD_SLOTS = {
+    1: (2, 0, 0, 0, 0, 0, 0, 0, 0),
+    2: (3, 0, 0, 0, 0, 0, 0, 0, 0),
+    3: (4, 2, 0, 0, 0, 0, 0, 0, 0),
+    4: (4, 3, 0, 0, 0, 0, 0, 0, 0),
+    5: (4, 3, 2, 0, 0, 0, 0, 0, 0),
+}
+
+
+@dataclass
+class PCOptions:
+    name: str
+    klass: str  # e.g., 'Wizard'
+    race: str | None
+    background: str | None
+    abilities: dict  # {str,dex,con,int,wis,cha}
+    ac: int
+
+
+# --- Creation ---
+
+
+def create_pc(opts: PCOptions) -> PlayerCharacter:
+    abilities = Abilities(**opts.abilities)
+    hd = HIT_DIE.get(opts.klass, 8)
+    con_mod = abilities.modifier("con")
+    max_hp = hd + con_mod  # L1 max per 5e baseline
+    pc = PlayerCharacter(
+        name=opts.name,
+        **{"class": opts.klass},
+        race=opts.race,
+        background=opts.background,
+        level=1,
+        abilities=abilities,
+        ac=opts.ac,
+        max_hp=max_hp,
+        current_hp=max_hp,
+        spell_slots=_spell_slots_for(opts.klass, 1),
+    )
+    return pc
+
+
+# --- Leveling ---
+
+
+def level_up(pc: PlayerCharacter, new_level: int) -> PlayerCharacter:
+    if new_level <= pc.level:
+        return pc
+    klass = pc.class_
+    hd = HIT_DIE.get(klass, 8)
+    con_mod = pc.ability_mod("con")
+    # Average HP per 5e (rounded up): d6=4, d8=5, d10=6, d12=7
+    avg = {6: 4, 8: 5, 10: 6, 12: 7}[hd]
+    gained = (new_level - pc.level) * (avg + con_mod)
+    pc.level = new_level
+    pc.max_hp += max(1, gained)
+    pc.current_hp = pc.max_hp
+    pc.spell_slots = _spell_slots_for(klass, new_level)
+    return pc
+
+
+# --- Inventory ---
+
+
+def add_item(pc: PlayerCharacter, name: str, qty: int = 1, **props) -> None:
+    for it in pc.inventory:
+        if it.name == name:
+            it.qty = (it.qty or 0) + qty
+            if props:
+                it.props = {**(it.props or {}), **props}
+            return
+    from grimbrain.models.pc import Item
+
+    pc.inventory.append(Item(name=name, qty=qty, props=props or None))
+
+
+# --- Spells ---
+
+
+def learn_spell(pc: PlayerCharacter, spell_name: str) -> None:
+    if spell_name not in pc.spells:
+        pc.spells.append(spell_name)
+
+
+# --- Slots helper ---
+
+
+def _spell_slots_for(klass: str, lvl: int) -> SpellSlots | None:
+    if klass == "Wizard":
+        t = WIZARD_SLOTS.get(lvl)
+        if t:
+            return SpellSlots(
+                l1=t[0],
+                l2=t[1],
+                l3=t[2],
+                l4=t[3],
+                l5=t[4],
+                l6=t[5],
+                l7=t[6],
+                l8=t[7],
+                l9=t[8],
+            )
+    return None
+
+
+# --- IO ---
+
+
+def save_pc(pc: PlayerCharacter, path: Path) -> None:
+    data = pc.model_dump(by_alias=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/grimbrain/cli.py
+++ b/grimbrain/cli.py
@@ -1,23 +1,27 @@
 from __future__ import annotations
 
-import os
 from functools import partial
 from pathlib import Path
 
-from rich import box
 import typer
 import typer.rich_utils as tru
+from rich import box
+
+from grimbrain.cli_character import char_app
 from grimbrain.cli_validate import validate_app
 
 tru.Panel = partial(tru.Panel, box=box.ASCII)
 
 app = typer.Typer(no_args_is_help=True)
 app.add_typer(validate_app, name="validate")
+app.add_typer(char_app, name="character")
+
 
 @app.callback()
 def main() -> None:
     """Grimbrain - solo D&D 5e engine (local-first)."""
-    
+
+
 @app.command()
 def play(
     pc: Path = typer.Option(..., exists=True, help="PC file (json)"),

--- a/grimbrain/cli_character.py
+++ b/grimbrain/cli_character.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from grimbrain.characters import PCOptions, create_pc, level_up, save_pc
+from grimbrain.validation import PrettyError, load_pc
+
+char_app = typer.Typer(help="Character creation and management")
+
+
+@char_app.command("create")
+def create(
+    name: str = typer.Option(...),
+    klass: str = typer.Option(..., help="Class, e.g. Wizard"),
+    race: str = typer.Option(None),
+    background: str = typer.Option(None),
+    ac: int = typer.Option(12),
+    str_: int = typer.Option(8, "--str"),
+    dex: int = typer.Option(8, "--dex"),
+    con: int = typer.Option(8, "--con"),
+    int_: int = typer.Option(8, "--int"),
+    wis: int = typer.Option(8, "--wis"),
+    cha: int = typer.Option(8, "--cha"),
+    out: Path = typer.Option(Path("pc.json"), help="Output file"),
+):
+    opts = PCOptions(
+        name=name,
+        klass=klass,
+        race=race,
+        background=background,
+        ac=ac,
+        abilities={
+            "str": str_,
+            "dex": dex,
+            "con": con,
+            "int": int_,
+            "wis": wis,
+            "cha": cha,
+        },
+    )
+    pc = create_pc(opts)
+    save_pc(pc, out)
+    typer.secho(f"Created PC → {out}", fg=typer.colors.GREEN)
+
+
+@char_app.command("level")
+def level(
+    file: Path = typer.Argument(..., exists=True),
+    to: int = typer.Option(..., help="New level"),
+):
+    try:
+        pc = load_pc(file)
+    except PrettyError as e:
+        raise typer.Exit(code=1) from e
+    pc = level_up(pc, to)
+    save_pc(pc, file)
+    typer.secho(f"Leveled {pc.name} to {pc.level}", fg=typer.colors.GREEN)

--- a/grimbrain/models/pc.py
+++ b/grimbrain/models/pc.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from typing import Dict, List, Optional
+
 from pydantic import BaseModel, Field, PositiveInt
-from typing import List, Optional, Dict
+
+ABILITY_ORDER = ("str", "dex", "con", "int", "wis", "cha")
 
 
 class Abilities(BaseModel):
@@ -12,11 +15,28 @@ class Abilities(BaseModel):
     wis: PositiveInt
     cha: PositiveInt
 
+    def modifier(self, name: str) -> int:
+        v = getattr(self, name)
+        return (v - 10) // 2
+
 
 class Item(BaseModel):
     name: str
     qty: PositiveInt | None = 1
     props: Dict[str, object] | None = None
+
+
+class SpellSlots(BaseModel):
+    # 1..9 levels; 0 means none
+    l1: int = 0
+    l2: int = 0
+    l3: int = 0
+    l4: int = 0
+    l5: int = 0
+    l6: int = 0
+    l7: int = 0
+    l8: int = 0
+    l9: int = 0
 
 
 class PlayerCharacter(BaseModel):
@@ -25,7 +45,7 @@ class PlayerCharacter(BaseModel):
     subclass: Optional[str] = None
     background: Optional[str] = None
     race: Optional[str] = None
-    level: PositiveInt
+    level: PositiveInt = 1
     proficiency_bonus: Optional[PositiveInt] = None
     abilities: Abilities
     ac: PositiveInt
@@ -33,11 +53,22 @@ class PlayerCharacter(BaseModel):
     current_hp: Optional[int] = None
     inventory: List[Item] = []
     spells: List[str] = []
-    notes: Optional[str] = None
+    spell_slots: SpellSlots | None = None
 
     class Config:
         populate_by_name = True
 
+    # --- Derived ---
+    @property
+    def prof(self) -> int:
+        if self.proficiency_bonus:
+            return self.proficiency_bonus
+        # 5e scaling: 1–4:+2, 5–8:+3, 9–12:+4, 13–16:+5, 17–20:+6
+        lvl = self.level
+        return 2 + ((lvl - 1) // 4)
 
-__all__ = ["PlayerCharacter", "Abilities", "Item"]
+    def ability_mod(self, name: str) -> int:
+        return self.abilities.modifier(name)
 
+
+__all__ = ["PlayerCharacter", "Abilities", "Item", "SpellSlots", "ABILITY_ORDER"]

--- a/schema/pc.schema.json
+++ b/schema/pc.schema.json
@@ -42,7 +42,21 @@
       }
     },
     "spells": {"type": "array", "items": {"type": "string"}},
-    "notes": {"type": "string"}
+    "spell_slots": {
+      "type": "object",
+      "properties": {
+        "l1": {"type": "integer"},
+        "l2": {"type": "integer"},
+        "l3": {"type": "integer"},
+        "l4": {"type": "integer"},
+        "l5": {"type": "integer"},
+        "l6": {"type": "integer"},
+        "l7": {"type": "integer"},
+        "l8": {"type": "integer"},
+        "l9": {"type": "integer"}
+      },
+      "additionalProperties": false
+    }
   },
   "additionalProperties": false
 }

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -1,0 +1,24 @@
+from grimbrain.characters import PCOptions, add_item, create_pc, learn_spell, level_up
+
+
+def test_create_and_level():
+    opts = PCOptions(
+        name="Elora",
+        klass="Wizard",
+        race="High Elf",
+        background="Sage",
+        ac=12,
+        abilities={"str": 8, "dex": 14, "con": 12, "int": 16, "wis": 10, "cha": 12},
+    )
+    pc = create_pc(opts)
+    assert pc.max_hp >= 6 + ((12 - 10) // 2)  # d6 + CON mod
+    assert pc.prof == 2
+
+    pc2 = level_up(pc, 3)
+    assert pc2.level == 3
+    assert pc2.spell_slots is not None and pc2.spell_slots.l2 >= 0
+
+    add_item(pc2, "Potion of Healing", 1)
+    learn_spell(pc2, "Magic Missile")
+    assert any(i.name == "Potion of Healing" for i in pc2.inventory)
+    assert "Magic Missile" in pc2.spells


### PR DESCRIPTION
## Summary
- add PlayerCharacter model with spell slots, ability mods, and prof calculation
- provide PC creation, leveling, inventory, and spell APIs
- introduce `grimbrain character` CLI with create/level commands and tests

## Testing
- `ruff check --fix grimbrain/models/pc.py grimbrain/characters.py`
- `black grimbrain/models/pc.py grimbrain/characters.py`
- `isort --profile black tests/test_character.py`
- `pytest -o addopts='' tests/test_character.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae0e9fce308327a0797134aebae510