### PR TITLE
Character System Expansion: Slots, Saves, Skills, Derived Stats, Point‑Buy

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ Level to 3:
 grimbrain character level pc_wizard.json --to 3
 ```
 
+Create with standard array assigned to INT, DEX, CON, STR, WIS, CHA:
+```bash
+grimbrain character array --name Elora --klass Wizard \
+  --assign int,dex,con,str,wis,cha --out pc_wizard.json
+```
+Create via point‑buy (27‑point):
+```bash
+grimbrain character pointbuy --name Nox --klass Warlock --stats 15,14,13,10,10,8
+```
+
 ## Python API
 ```python
 from grimbrain.retrieval.query_router import run_query

--- a/grimbrain/pointbuy.py
+++ b/grimbrain/pointbuy.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+STANDARD_ARRAY = (15, 14, 13, 12, 10, 8)
+COSTS = {8: 0, 9: 1, 10: 2, 11: 3, 12: 4, 13: 5, 14: 7, 15: 9}  # 27-point buy
+
+
+@dataclass
+class PointBuy:
+    str: int
+    dex: int
+    con: int
+    int: int
+    wis: int
+    cha: int
+
+    @property
+    def cost(self) -> int:
+        return sum(COSTS[v] for v in (self.str, self.dex, self.con, self.int, self.wis, self.cha))
+
+    def as_dict(self) -> dict:
+        return {
+            "str": self.str,
+            "dex": self.dex,
+            "con": self.con,
+            "int": self.int,
+            "wis": self.wis,
+            "cha": self.cha,
+        }

--- a/grimbrain/rules_core.py
+++ b/grimbrain/rules_core.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+# Saving throw proficiencies by class (SRD baseline)
+CLASS_SAVE_PROFS = {
+    "Barbarian": {"str", "con"},
+    "Bard": {"dex", "cha"},
+    "Cleric": {"wis", "cha"},
+    "Druid": {"int", "wis"},
+    "Fighter": {"str", "con"},
+    "Monk": {"str", "dex"},
+    "Paladin": {"wis", "cha"},
+    "Ranger": {"str", "dex"},
+    "Rogue": {"dex", "int"},
+    "Sorcerer": {"con", "cha"},
+    "Warlock": {"wis", "cha"},
+    "Wizard": {"int", "wis"},
+}
+
+# Simple skill packages (backgrounds can add more later)
+BACKGROUND_SKILLS = {
+    "Sage": {"arcana", "history"},
+    "Soldier": {"athletics", "intimidation"},
+    "Acolyte": {"insight", "religion"},
+}
+
+# Full casters slots (L1–L9) – tuple per level (l1..l9)
+FULL_CASTER_SLOTS = {
+    1: (2, 0, 0, 0, 0, 0, 0, 0, 0),
+    2: (3, 0, 0, 0, 0, 0, 0, 0, 0),
+    3: (4, 2, 0, 0, 0, 0, 0, 0, 0),
+    4: (4, 3, 0, 0, 0, 0, 0, 0, 0),
+    5: (4, 3, 2, 0, 0, 0, 0, 0, 0),
+    6: (4, 3, 3, 0, 0, 0, 0, 0, 0),
+    7: (4, 3, 3, 1, 0, 0, 0, 0, 0),
+    8: (4, 3, 3, 2, 0, 0, 0, 0, 0),
+    9: (4, 3, 3, 3, 1, 0, 0, 0, 0),
+    10: (4, 3, 3, 3, 2, 0, 0, 0, 0),
+    11: (4, 3, 3, 3, 2, 1, 0, 0, 0),
+    12: (4, 3, 3, 3, 2, 1, 0, 0, 0),
+    13: (4, 3, 3, 3, 2, 1, 1, 0, 0),
+    14: (4, 3, 3, 3, 2, 1, 1, 0, 0),
+    15: (4, 3, 3, 3, 2, 1, 1, 1, 0),
+    16: (4, 3, 3, 3, 2, 1, 1, 1, 0),
+    17: (4, 3, 3, 3, 2, 1, 1, 1, 1),
+    18: (4, 3, 3, 3, 3, 1, 1, 1, 1),
+    19: (4, 3, 3, 3, 3, 2, 1, 1, 1),
+    20: (4, 3, 3, 3, 3, 2, 2, 1, 1),
+}
+
+# Half-caster / third-caster progression can be added later when needed.
+
+# Pact magic (Warlock) – slots per level (level, #slots, slot level)
+PACT_MAGIC = {
+    1: (1, 1),
+    2: (2, 1),
+    3: (2, 2),
+    4: (2, 2),
+    5: (2, 3),
+    6: (2, 3),
+    7: (2, 4),
+    8: (2, 4),
+    9: (2, 5),
+    10: (2, 5),
+    11: (3, 5),
+    12: (3, 5),
+    13: (3, 5),
+    14: (3, 5),
+    15: (3, 5),
+    16: (3, 5),
+    17: (4, 5),
+    18: (4, 5),
+    19: (4, 5),
+    20: (4, 5),
+}

--- a/tests/test_character_derived.py
+++ b/tests/test_character_derived.py
@@ -1,0 +1,29 @@
+from grimbrain.characters import PCOptions, create_pc
+
+
+def _wiz():
+    return PCOptions(
+        name="Elora",
+        klass="Wizard",
+        race="High Elf",
+        background="Sage",
+        ac=12,
+        abilities={"str": 8, "dex": 14, "con": 12, "int": 16, "wis": 10, "cha": 12},
+    )
+
+
+def test_saves_and_skills():
+    pc = create_pc(_wiz())
+    # Sage adds arcana/history; Wizard saves int/wis
+    assert pc.save_proficiencies == {"int", "wis"}
+    assert {"arcana", "history"}.issubset(pc.skill_proficiencies)
+    # Passive Perception baseline
+    assert pc.passive_perception >= 10
+
+
+def test_spell_slots_tables():
+    from grimbrain.characters import level_up
+
+    pc = create_pc(_wiz())
+    pc = level_up(pc, 5)
+    assert pc.spell_slots and pc.spell_slots.l3 >= 2


### PR DESCRIPTION
## Summary
- extend `PlayerCharacter` with skill/save/armor/weapon proficiencies and derived stat helpers
- add core tables for save proficiencies, background skills, spell slots and pact magic
- introduce point-buy helper and CLI commands for standard array and point-buy character creation
- document new flows and verify with tests for derived stats and slot tables

## Testing
- `pytest -q --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68ae17b4e3408327a0ab21c322e10648