### PR TITLE
PR 7 — Character System: Finish Class Coverage (Half‑ & Third‑Casters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ Create via point‑buy (27‑point):
 grimbrain character pointbuy --name Nox --klass Warlock --stats 15,14,13,10,10,8
 ```
 
+Supports full casters (Wizard, Cleric, Druid, Sorcerer, Bard), half‑casters
+(Paladin, Ranger), third‑casters (Eldritch Knight, Arcane Trickster), and
+Warlock pact magic slot rules.
+
+Create an Eldritch Knight:
+```bash
+grimbrain character create --name Tharn --klass Fighter --subclass "Eldritch Knight" --ac 17 \
+  --str 16 --dex 12 --con 14 --int 10 --wis 10 --cha 8 --out pc_tharn.json
+```
+Create an Arcane Trickster:
+```bash
+grimbrain character create --name Sable --klass Rogue --subclass "Arcane Trickster" --ac 15 \
+  --str 10 --dex 16 --con 12 --int 14 --wis 10 --cha 8 --out pc_sable.json
+```
+
 ## Python API
 ```python
 from grimbrain.retrieval.query_router import run_query

--- a/grimbrain/cli_character.py
+++ b/grimbrain/cli_character.py
@@ -14,6 +14,7 @@ char_app = typer.Typer(help="Character creation and management")
 def create(
     name: str = typer.Option(...),
     klass: str = typer.Option(..., help="Class, e.g. Wizard"),
+    subclass: str = typer.Option(None, help="Subclass (for EK/AT etc.)"),
     race: str = typer.Option(None),
     background: str = typer.Option(None),
     ac: int = typer.Option(12),
@@ -28,6 +29,7 @@ def create(
     opts = PCOptions(
         name=name,
         klass=klass,
+        subclass=subclass,
         race=race,
         background=background,
         ac=ac,
@@ -49,6 +51,7 @@ def create(
 def make_from_array(
     name: str = typer.Option(...),
     klass: str = typer.Option(...),
+    subclass: str = typer.Option(None, help="Subclass"),
     race: str = typer.Option(None),
     background: str = typer.Option(None),
     ac: int = typer.Option(12),
@@ -64,6 +67,7 @@ def make_from_array(
     opts = PCOptions(
         name=name,
         klass=klass,
+        subclass=subclass,
         race=race,
         background=background,
         ac=ac,
@@ -78,6 +82,7 @@ def make_from_array(
 def make_from_pointbuy(
     name: str = typer.Option(...),
     klass: str = typer.Option(...),
+    subclass: str = typer.Option(None, help="Subclass"),
     race: str = typer.Option(None),
     background: str = typer.Option(None),
     ac: int = typer.Option(12),
@@ -94,6 +99,7 @@ def make_from_pointbuy(
     opts = PCOptions(
         name=name,
         klass=klass,
+        subclass=subclass,
         race=race,
         background=background,
         ac=ac,

--- a/tests/test_slots_progressions.py
+++ b/tests/test_slots_progressions.py
@@ -1,0 +1,39 @@
+from grimbrain.characters import PCOptions, create_pc, level_up
+
+
+def _opts(klass, subclass=None):
+    return PCOptions(
+        name="Test", klass=klass, subclass=subclass, race=None, background=None, ac=12,
+        abilities={"str":10,"dex":10,"con":10,"int":10,"wis":10,"cha":10}
+    )
+
+
+def test_paladin_half_caster():
+    pc = create_pc(_opts("Paladin"))
+    assert pc.spell_slots is None  # L1 no slots
+    pc = level_up(pc, 2)
+    assert pc.spell_slots and pc.spell_slots.l1 == 2
+    pc = level_up(pc, 5)
+    assert pc.spell_slots.l2 >= 1  # gains 2nd-level slots by 5
+
+
+def test_ranger_half_caster():
+    pc = create_pc(_opts("Ranger"))
+    assert pc.spell_slots is None
+    pc = level_up(pc, 3)
+    assert pc.spell_slots and pc.spell_slots.l1 >= 3
+
+
+def test_eldritch_knight_third_caster():
+    pc = create_pc(_opts("Fighter", "Eldritch Knight"))
+    assert pc.spell_slots is None  # L1, no subclass yet
+    pc = level_up(pc, 3)
+    assert pc.spell_slots and pc.spell_slots.l1 == 2
+    pc = level_up(pc, 7)
+    assert pc.spell_slots.l2 >= 2
+
+
+def test_arcane_trickster_third_caster():
+    pc = create_pc(_opts("Rogue", "Arcane Trickster"))
+    pc = level_up(pc, 3)
+    assert pc.spell_slots and pc.spell_slots.l1 >= 2


### PR DESCRIPTION
## Summary
- support half- and third-caster spell slot progressions with helper functions
- allow specifying subclass on the CLI so Eldritch Knights and Arcane Tricksters gain slots
- add tests covering Paladin, Ranger, Eldritch Knight, and Arcane Trickster progressions

## Testing
- `pytest` *(fails: Required test coverage of 70% not reached. Total coverage: 34.06%)*

------
https://chatgpt.com/codex/tasks/task_e_68af0130160c8327bbdca614baa84feb