### PR TITLE
Add character sheet rendering and markdown export

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ grimbrain character create --name Sable --klass Rogue --subclass "Arcane Trickst
   --str 10 --dex 16 --con 12 --int 14 --wis 10 --cha 8 --out pc_sable.json
 ```
 
+Render to terminal:
+```bash
+grimbrain character sheet pc_wizard.json --fmt tty
+```
+Export to Markdown:
+```bash
+grimbrain character sheet pc_wizard.json --fmt md --out outputs/elora_sheet.md
+```
+
 ## Python API
 ```python
 from grimbrain.retrieval.query_router import run_query

--- a/grimbrain/sheet.py
+++ b/grimbrain/sheet.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from grimbrain.models.pc import ABILITY_ORDER, PlayerCharacter
+
+ABIL_NAMES = {
+    "str": "STR",
+    "dex": "DEX",
+    "con": "CON",
+    "int": "INT",
+    "wis": "WIS",
+    "cha": "CHA",
+}
+
+
+def ability_block(pc: PlayerCharacter) -> Table:
+    t = Table(box=None, show_header=False, expand=False)
+    for a in ABILITY_ORDER:
+        score = getattr(pc.abilities, a)
+        mod = pc.ability_mod(a)
+        t.add_row(f"[bold]{ABIL_NAMES[a]}[/]", f"{score:>2} ({mod:+d})")
+    return t
+
+
+def prof_block(pc: PlayerCharacter) -> Table:
+    t = Table(box=None, show_header=False, expand=False)
+    t.add_row("Prof.", f"+{pc.prof}")
+    t.add_row("Saves", ", ".join(sorted(pc.save_proficiencies)) or "—")
+    t.add_row("Skills", ", ".join(sorted(pc.skill_proficiencies)) or "—")
+    return t
+
+
+def defense_block(pc: PlayerCharacter) -> Table:
+    t = Table(box=None, show_header=False, expand=False)
+    t.add_row("AC", str(pc.ac))
+    t.add_row("HP", f"{pc.current_hp}/{pc.max_hp}")
+    t.add_row("Init.", f"{pc.initiative:+d}")
+    t.add_row("Passive Perception", str(pc.passive_perception))
+    return t
+
+
+def slots_block(pc: PlayerCharacter) -> Table:
+    t = Table(box=None, show_header=False, expand=False)
+    if not pc.spell_slots:
+        t.add_row("Slots", "—")
+        return t
+    levels = [f"L{i}" for i in range(1, 10)]
+    values = [getattr(pc.spell_slots, f"l{i}") for i in range(1, 10)]
+    t.add_row("Slots", ", ".join(f"{lvl}:{v}" for lvl, v in zip(levels, values) if v))
+    return t
+
+
+def inventory_block(pc: PlayerCharacter) -> Table:
+    t = Table(box=None, show_header=True, expand=False)
+    t.add_column("Item")
+    t.add_column("Qty")
+    t.add_column("Props")
+    if not pc.inventory:
+        t.add_row("—", "—", "—")
+        return t
+    for it in pc.inventory:
+        t.add_row(
+            it.name,
+            str(it.qty or 1),
+            (
+                ", ".join(f"{k}={v}" for k, v in (it.props or {}).items())
+                if it.props
+                else ""
+            ),
+        )
+    return t
+
+
+def render_console(pc: PlayerCharacter) -> None:
+    c = Console()
+    header = f"[bold]{pc.name}[/] — {pc.class_}{f' ({pc.subclass})' if pc.subclass else ''}  L{pc.level}"
+    c.rule(header)
+    c.print(Panel(ability_block(pc), title="Abilities", border_style="cyan"))
+    c.print(Panel(prof_block(pc), title="Proficiencies", border_style="magenta"))
+    c.print(Panel(defense_block(pc), title="Defense", border_style="green"))
+    c.print(Panel(slots_block(pc), title="Spellcasting", border_style="yellow"))
+    c.print(Panel(inventory_block(pc), title="Inventory", border_style="blue"))
+
+
+MD_HEADER = (
+    "# {name}\n\n"
+    "**Class:** {klass}{sub}  \n"
+    "**Level:** {level}  \n"
+    "**AC:** {ac}  \n"
+    "**HP:** {hp}\n\n"
+)
+
+
+def to_markdown(pc: PlayerCharacter) -> str:
+    sub = f" ({pc.subclass})" if pc.subclass else ""
+    out = MD_HEADER.format(
+        name=pc.name,
+        klass=pc.class_,
+        sub=sub,
+        level=pc.level,
+        ac=pc.ac,
+        hp=f"{pc.current_hp}/{pc.max_hp}",
+    )
+    out += "## Abilities\n\n"
+    for a in ABILITY_ORDER:
+        score = getattr(pc.abilities, a)
+        mod = pc.ability_mod(a)
+        out += f"- **{ABIL_NAMES[a]}**: {score} ({mod:+d})\n"
+    out += "\n## Proficiencies\n\n"
+    saves = ", ".join(sorted(pc.save_proficiencies)) or "—"
+    skills = ", ".join(sorted(pc.skill_proficiencies)) or "—"
+    out += (
+        f"- **Proficiency Bonus**: +{pc.prof}\n"
+        f"- **Saving Throws**: {saves}\n"
+        f"- **Skills**: {skills}\n\n"
+    )
+    out += "## Derived\n\n"
+    out += (
+        f"- **Initiative**: {pc.initiative:+d}\n"
+        f"- **Passive Perception**: {pc.passive_perception}\n\n"
+    )
+    out += "## Spellcasting\n\n"
+    if pc.spell_slots:
+        parts = []
+        for i in range(1, 10):
+            v = getattr(pc.spell_slots, f"l{i}")
+            if v:
+                parts.append(f"L{i}:{v}")
+        out += "- **Slots**: " + (", ".join(parts) if parts else "—") + "\n\n"
+    else:
+        out += "- **Slots**: —\n\n"
+    out += "## Inventory\n\n"
+    if not pc.inventory:
+        out += "- —\n"
+    else:
+        for it in pc.inventory:
+            props = (
+                ", ".join(f"{k}={v}" for k, v in (it.props or {}).items())
+                if it.props
+                else ""
+            )
+            out += f"- {it.name} x{it.qty or 1} {props}\n"
+    return out
+
+
+def save_markdown(pc: PlayerCharacter, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(to_markdown(pc), encoding="utf-8")

--- a/tests/test_sheet_markdown.py
+++ b/tests/test_sheet_markdown.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from grimbrain.characters import PCOptions, create_pc
+from grimbrain.sheet import to_markdown
+
+
+def test_sheet_md_contains_core_fields(tmp_path: Path):
+    pc = create_pc(
+        PCOptions(
+            name="Elora",
+            klass="Wizard",
+            race="High Elf",
+            background="Sage",
+            ac=12,
+            abilities={"str": 8, "dex": 14, "con": 12, "int": 16, "wis": 10, "cha": 12},
+        )
+    )
+    md = to_markdown(pc)
+    assert "# Elora" in md
+    assert "**Class:** Wizard" in md
+    assert "## Abilities" in md and "**INT**" in md
+    assert "## Proficiencies" in md and "Proficiency Bonus" in md
+    assert "## Spellcasting" in md


### PR DESCRIPTION
## Summary
- add Rich-based character sheet renderer and markdown exporter
- provide `grimbrain character sheet` CLI command
- test markdown output for essential sections

## Testing
- `ruff check --fix grimbrain/sheet.py grimbrain/cli_character.py tests/test_sheet_markdown.py`
- `black grimbrain/sheet.py grimbrain/cli_character.py tests/test_sheet_markdown.py`
- `isort grimbrain/sheet.py grimbrain/cli_character.py tests/test_sheet_markdown.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0f5ac82c83279fff0a927b744571