### PR TITLE
feat: polish character sheet outputs with metadata and CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ Export to PDF:
 grimbrain character sheet pc_wizard.json --fmt pdf --out outputs/elora_sheet.pdf
 ```
 
+Include metadata footer and show zero slots:
+```bash
+grimbrain character sheet pc_elora.json --fmt md --meta campaign=Starter --meta seed=1 --show-zero-slots
+```
+
+PDF with logo and metadata:
+```bash
+grimbrain character sheet pc_elora.json --fmt pdf --logo assets/grimbrain_logo.png \
+  --meta campaign=Starter --meta seed=1 --out outputs/elora_sheet.pdf
+```
+
 ## Python API
 ```python
 from grimbrain.retrieval.query_router import run_query

--- a/grimbrain/sheet_pdf.py
+++ b/grimbrain/sheet_pdf.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+from datetime import datetime
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
 from pathlib import Path
 
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
-from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib.units import inch
-from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+from reportlab.platypus import (
+    Image,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
 
 from grimbrain.models.pc import ABILITY_ORDER, PlayerCharacter
-
 
 SMALL = 9
 NORMAL = 10
@@ -37,10 +47,33 @@ def _abilities_table(pc: PlayerCharacter) -> Table:
     return t
 
 
+def _caps_csv(items: Iterable[str]) -> str:
+    return ", ".join(s.upper() for s in sorted(items)) if items else "—"
+
+
+def _slots_line(pc: PlayerCharacter, show_zero: bool) -> str:
+    parts: list[str] = []
+    if pc.spell_slots:
+        for i in range(1, 10):
+            v = getattr(pc.spell_slots, f"l{i}")
+            if v or show_zero:
+                parts.append(f"L{i}:{v}")
+    return ", ".join(parts) if parts else "—"
+
+
+def _pkg_version() -> str:
+    try:
+        return pkg_version("grimbrain")
+    except PackageNotFoundError:  # pragma: no cover - local checkout
+        return "0.0"
+
+
 def _profs_table(pc: PlayerCharacter) -> Table:
-    saves = ", ".join(sorted(pc.save_proficiencies)) or "—"
-    skills = ", ".join(sorted(pc.skill_proficiencies)) or "—"
-    data = [["Prof. Bonus", f"+{pc.prof}"], ["Saves", saves], ["Skills", skills]]
+    data = [
+        ["Prof. Bonus", f"+{pc.prof}"],
+        ["Saves", _caps_csv(pc.save_proficiencies)],
+        ["Skills", _caps_csv(pc.skill_proficiencies)],
+    ]
     t = Table(data, hAlign="LEFT", colWidths=[1.2 * inch, 4.3 * inch])
     t.setStyle(
         TableStyle(
@@ -71,7 +104,16 @@ def _defense_table(pc: PlayerCharacter) -> Table:
     t = Table(
         data,
         hAlign="LEFT",
-        colWidths=[0.5 * inch, 0.6 * inch, 0.5 * inch, 1.0 * inch, 0.6 * inch, 0.7 * inch, 1.6 * inch, 0.7 * inch],
+        colWidths=[
+            0.5 * inch,
+            0.6 * inch,
+            0.5 * inch,
+            1.0 * inch,
+            0.6 * inch,
+            0.7 * inch,
+            1.6 * inch,
+            0.7 * inch,
+        ],
     )
     t.setStyle(
         TableStyle(
@@ -87,17 +129,9 @@ def _defense_table(pc: PlayerCharacter) -> Table:
     return t
 
 
-def _slots_table(pc: PlayerCharacter) -> Table:
-    if not pc.spell_slots:
-        data = [["Slots", "—"]]
-        widths = [0.7 * inch, 5.0 * inch]
-    else:
-        labels = [f"L{i}" for i in range(1, 10)]
-        values = [getattr(pc.spell_slots, f"l{i}") for i in range(1, 10)]
-        parts = [f"{l}:{v}" for l, v in zip(labels, values) if v]
-        data = [["Slots", ", ".join(parts) if parts else "—"]]
-        widths = [0.7 * inch, 5.0 * inch]
-    t = Table(data, hAlign="LEFT", colWidths=widths)
+def _slots_table(pc: PlayerCharacter, show_zero: bool) -> Table:
+    data = [["Slots", _slots_line(pc, show_zero)]]
+    t = Table(data, hAlign="LEFT", colWidths=[0.7 * inch, 5.0 * inch])
     t.setStyle(
         TableStyle(
             [
@@ -117,7 +151,11 @@ def _inventory_table(pc: PlayerCharacter) -> Table:
         rows.append(["—", "—", "—"])
     else:
         for it in pc.inventory:
-            props = ", ".join(f"{k}={v}" for k, v in (it.props or {}).items()) if it.props else ""
+            props = (
+                ", ".join(f"{k}={v}" for k, v in (it.props or {}).items())
+                if it.props
+                else ""
+            )
             rows.append([it.name, str(it.qty or 1), props])
     t = Table(rows, hAlign="LEFT", colWidths=[3.0 * inch, 0.5 * inch, 2.2 * inch])
     t.setStyle(
@@ -133,25 +171,63 @@ def _inventory_table(pc: PlayerCharacter) -> Table:
     return t
 
 
-def save_pdf(pc: PlayerCharacter, path: Path) -> None:
+def save_pdf(
+    pc: PlayerCharacter,
+    path: Path,
+    meta: dict[str, str] | None = None,
+    logo: Path | None = None,
+    show_zero_slots: bool = False,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     doc = SimpleDocTemplate(
-        str(path), pagesize=letter, leftMargin=36, rightMargin=36, topMargin=36, bottomMargin=36
+        str(path),
+        pagesize=letter,
+        leftMargin=36,
+        rightMargin=36,
+        topMargin=36,
+        bottomMargin=36,
     )
     styles = getSampleStyleSheet()
-    title = Paragraph(
-        f"<b>{pc.name}</b> — {pc.class_}{f' ({pc.subclass})' if pc.subclass else ''}  L{pc.level}",
-        styles["Title"],
-    )
-    elems = [title, Spacer(1, 0.2 * inch)]
-    elems += [Paragraph("<b>Abilities</b>", styles["Heading3"]), _abilities_table(pc), Spacer(1, 0.15 * inch)]
-    elems += [
+
+    title_text = f"<b>{pc.name}</b> — {pc.class_}{f' ({pc.subclass})' if pc.subclass else ''}  L{pc.level}"
+    title_para = Paragraph(title_text, styles["Title"])
+    if logo and logo.exists():
+        img = Image(str(logo))
+        img._restrictSize(1.2 * inch, 1.2 * inch)
+        header = Table([[img, title_para]], colWidths=[1.3 * inch, None], hAlign="LEFT")
+    else:
+        header = Table([[title_para]], colWidths=[None], hAlign="LEFT")
+
+    left = [
+        Paragraph("<b>Abilities</b>", styles["Heading3"]),
+        _abilities_table(pc),
+        Spacer(1, 0.12 * inch),
         Paragraph("<b>Proficiencies</b>", styles["Heading3"]),
         _profs_table(pc),
-        Spacer(1, 0.15 * inch),
+        Spacer(1, 0.12 * inch),
+        Paragraph("<b>Defense</b>", styles["Heading3"]),
+        _defense_table(pc),
     ]
-    elems += [Paragraph("<b>Defense</b>", styles["Heading3"]), _defense_table(pc), Spacer(1, 0.15 * inch)]
-    elems += [Paragraph("<b>Spellcasting</b>", styles["Heading3"]), _slots_table(pc), Spacer(1, 0.15 * inch)]
-    elems += [Paragraph("<b>Inventory</b>", styles["Heading3"]), _inventory_table(pc)]
-    doc.build(elems)
+    right = [
+        Paragraph("<b>Spellcasting</b>", styles["Heading3"]),
+        _slots_table(pc, show_zero_slots),
+        Spacer(1, 0.12 * inch),
+        Paragraph("<b>Inventory</b>", styles["Heading3"]),
+        _inventory_table(pc),
+    ]
 
+    left_tbl = Table([[x] for x in left], hAlign="LEFT")
+    right_tbl = Table([[x] for x in right], hAlign="LEFT")
+
+    body = Table([[left_tbl, right_tbl]], colWidths=[3.4 * inch, 3.4 * inch])
+    body.setStyle(TableStyle([("VALIGN", (0, 0), (-1, -1), "TOP")]))
+
+    meta = meta or {}
+    meta.setdefault("version", _pkg_version())
+    meta.setdefault("generated", datetime.utcnow().isoformat() + "Z")
+    footer_text = "  •  ".join(f"{k.upper()}: {v}" for k, v in meta.items())
+    footer = Paragraph(
+        f"<font size=9 color=grey>{footer_text}</font>", styles["Normal"]
+    )
+
+    doc.build([header, Spacer(1, 0.15 * inch), body, Spacer(1, 0.2 * inch), footer])

--- a/tests/test_sheet_polish.py
+++ b/tests/test_sheet_polish.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pytest
+
+from grimbrain.characters import PCOptions, create_pc
+from grimbrain.sheet import to_markdown
+
+try:
+    from grimbrain.sheet_pdf import save_pdf
+except ModuleNotFoundError:  # pragma: no cover - optional dep
+    save_pdf = None
+
+
+def _pc():
+    return create_pc(
+        PCOptions(
+            name="Elora",
+            klass="Wizard",
+            race="High Elf",
+            background="Sage",
+            ac=12,
+            abilities={"str": 8, "dex": 14, "con": 12, "int": 16, "wis": 10, "cha": 12},
+        )
+    )
+
+
+def test_md_footer_and_caps(tmp_path: Path):
+    md = to_markdown(
+        _pc(), meta={"campaign": "Starter", "seed": "1"}, show_zero_slots=True
+    )
+    assert "INT, WIS" in md
+    assert "L2:0" in md and "SLOTS" in md.upper()
+    assert "CAMPAIGN: Starter" in md and "SEED: 1" in md
+
+
+def test_pdf_footer(tmp_path: Path):
+    pytest.importorskip("reportlab")
+    assert save_pdf is not None
+    p = tmp_path / "elora_polished.pdf"
+    save_pdf(_pc(), p, meta={"campaign": "Starter", "seed": "1"}, show_zero_slots=True)
+    assert p.exists() and p.stat().st_size > 1000


### PR DESCRIPTION
## Summary
- add metadata footer, caps labels, and zero-slot toggle across sheet outputs
- support PDF logo header and two-column layout
- expose `--meta`, `--logo`, and `--show-zero-slots` options for `character sheet`

## Testing
- `python -m ruff check --fix grimbrain/cli_character.py grimbrain/sheet.py grimbrain/sheet_pdf.py tests/test_sheet_polish.py`
- `python -m black grimbrain/cli_character.py grimbrain/sheet.py grimbrain/sheet_pdf.py tests/test_sheet_polish.py`
- `python -m isort grimbrain/cli_character.py grimbrain/sheet.py grimbrain/sheet_pdf.py tests/test_sheet_polish.py`
- `pytest tests/test_sheet_polish.py tests/test_sheet_markdown.py` *(fails: Required test coverage of 70% not reached)*
- `pip install pre-commit` *(fail: Could not find a version that satisfies the requirement pre-commit)*
- `pip install reportlab` *(fail: Could not find a version that satisfies the requirement reportlab)*

------
https://chatgpt.com/codex/tasks/task_e_68af4238bc888327a7d8d9b2f5ddff01