### PR TITLE
feat: starting equipment & proficiency packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ grimbrain character sheet pc_elora.json --fmt pdf --logo assets/grimbrain_logo.p
   --meta campaign=Starter --meta seed=1 --out outputs/elora_sheet.pdf
 ```
 
+### Starter equipment
+
+Create a PC with class/background starter packs:
+```bash
+grimbrain character create --name Elora --klass Wizard --background Sage --ac 12 \
+  --str 8 --dex 14 --con 12 --int 16 --wis 10 --cha 12 --starter --out pc_elora.json
+```
+
+Apply a kit to an existing PC:
+
+```bash
+grimbrain character equip pc_elora.json --preset Wizard
+grimbrain character equip pc_elora.json --preset Sage
+```
+
+Sheets will now list Languages and Tools under Proficiencies.
+
 ## Python API
 ```python
 from grimbrain.retrieval.query_router import run_query

--- a/grimbrain/characters.py
+++ b/grimbrain/characters.py
@@ -5,6 +5,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from grimbrain.models.pc import Abilities, PlayerCharacter, SpellSlots
+from grimbrain.rules_equipment import (
+    BACKGROUND_KITS,
+    BACKGROUND_LANGUAGES,
+    BACKGROUND_TOOLS,
+    CLASS_KITS,
+    KitItem,
+)
 from grimbrain.rules_core import (
     BACKGROUND_SKILLS,
     CLASS_SAVE_PROFS,
@@ -102,6 +109,26 @@ def add_item(pc: PlayerCharacter, name: str, qty: int = 1, **props) -> None:
     from grimbrain.models.pc import Item
 
     pc.inventory.append(Item(name=name, qty=qty, props=props or None))
+
+
+def apply_items(pc: PlayerCharacter, kit: list[KitItem]) -> None:
+    for it in kit:
+        add_item(pc, it.name, it.qty, **(it.props or {}))
+
+
+def apply_starter_kits(pc: PlayerCharacter) -> None:
+    kit = CLASS_KITS.get(pc.class_, [])
+    apply_items(pc, kit)
+    if pc.background:
+        apply_items(pc, BACKGROUND_KITS.get(pc.background, []))
+        langs = BACKGROUND_LANGUAGES.get(pc.background, [])
+        for l in langs:
+            if l not in pc.languages:
+                pc.languages.append(l)
+        tools = BACKGROUND_TOOLS.get(pc.background, [])
+        for t in tools:
+            if t not in pc.tool_proficiencies:
+                pc.tool_proficiencies.append(t)
 
 
 # --- Spells ---

--- a/grimbrain/cli_character.py
+++ b/grimbrain/cli_character.py
@@ -4,10 +4,18 @@ from pathlib import Path
 
 import typer
 
-from grimbrain.characters import PCOptions, create_pc, level_up, save_pc
+from grimbrain.characters import (
+    PCOptions,
+    add_item,
+    apply_starter_kits,
+    create_pc,
+    level_up,
+    save_pc,
+)
 from grimbrain.sheet import render_console, save_markdown
 from grimbrain.sheet_pdf import save_pdf
 from grimbrain.validation import PrettyError, load_pc
+from grimbrain.rules_equipment import CLASS_KITS, BACKGROUND_KITS
 
 char_app = typer.Typer(help="Character creation and management")
 
@@ -27,6 +35,9 @@ def create(
     wis: int = typer.Option(8, "--wis"),
     cha: int = typer.Option(8, "--cha"),
     out: Path = typer.Option(Path("pc.json"), help="Output file"),
+    starter: bool = typer.Option(
+        False, help="Apply class/background equipment & prof packs"
+    ),
 ):
     opts = PCOptions(
         name=name,
@@ -45,6 +56,8 @@ def create(
         },
     )
     pc = create_pc(opts)
+    if starter:
+        apply_starter_kits(pc)
     save_pc(pc, out)
     typer.secho(f"Created PC → {out}", fg=typer.colors.GREEN)
 
@@ -64,6 +77,9 @@ def make_from_array(
         "int,dex,con,str,wis,cha", help="Order to assign stats (comma sep)"
     ),
     out: Path = typer.Option(Path("pc.json")),
+    starter: bool = typer.Option(
+        False, help="Apply class/background starter packs"
+    ),
 ):
     vals = [int(x) for x in arr.split(",")]
     keys = assign.split(",")
@@ -78,6 +94,8 @@ def make_from_array(
         abilities=abilities,
     )
     pc = create_pc(opts)
+    if starter:
+        apply_starter_kits(pc)
     save_pc(pc, out)
     typer.secho(f"Created PC from array → {out}", fg=typer.colors.GREEN)
 
@@ -92,6 +110,9 @@ def make_from_pointbuy(
     ac: int = typer.Option(12),
     stats: str = typer.Option("15,14,13,12,10,8"),
     out: Path = typer.Option(Path("pc.json")),
+    starter: bool = typer.Option(
+        False, help="Apply class/background starter packs"
+    ),
 ):
     vals = [int(x) for x in stats.split(",")]
     abilities = {k: v for k, v in zip(["str", "dex", "con", "int", "wis", "cha"], vals)}
@@ -110,6 +131,8 @@ def make_from_pointbuy(
         abilities=pb.as_dict(),
     )
     pc = create_pc(opts)
+    if starter:
+        apply_starter_kits(pc)
     save_pc(pc, out)
     typer.secho(
         f"Created PC via point-buy (cost={pb.cost}) → {out}",
@@ -177,3 +200,33 @@ def sheet(
         typer.secho(f"Wrote {target}", fg=typer.colors.GREEN)
     else:
         raise typer.BadParameter("Unknown format (use 'tty' or 'md' or 'pdf')")
+
+
+@char_app.command("equip")
+def equip(
+    file: Path = typer.Argument(..., exists=True),
+    preset: str = typer.Option(
+        ..., help="Class or background preset, e.g. 'Wizard' or 'Sage'"
+    ),
+):
+    """Apply a class or background equipment preset to an existing PC."""
+    pc = load_pc(file)
+    applied = False
+    if preset in CLASS_KITS:
+        apply_items = CLASS_KITS[preset]
+        from grimbrain.characters import apply_items as _apply_items
+
+        _apply_items(pc, apply_items)
+        applied = True
+    if preset in BACKGROUND_KITS:
+        apply_items = BACKGROUND_KITS[preset]
+        from grimbrain.characters import apply_items as _apply_items
+
+        _apply_items(pc, apply_items)
+        applied = True
+    if not applied:
+        raise typer.BadParameter(
+            f"Unknown preset '{preset}'. Try a class or background name."
+        )
+    save_pc(pc, file)
+    typer.secho(f"Applied '{preset}' kit → {file}", fg=typer.colors.GREEN)

--- a/grimbrain/models/pc.py
+++ b/grimbrain/models/pc.py
@@ -81,6 +81,8 @@ class PlayerCharacter(BaseModel):
     skill_proficiencies: Set[str] = set()
     armor_proficiencies: Set[str] = set()
     weapon_proficiencies: Set[str] = set()
+    languages: List[str] = []
+    tool_proficiencies: List[str] = []
 
     class Config:
         populate_by_name = True

--- a/grimbrain/rules_equipment.py
+++ b/grimbrain/rules_equipment.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class KitItem:
+    name: str
+    qty: int = 1
+    props: dict | None = None
+
+
+def items(*pairs: tuple[str, int] | tuple[str, int, dict]) -> list[KitItem]:
+    out: list[KitItem] = []
+    for p in pairs:
+        if len(p) == 2:
+            n, q = p
+            out.append(KitItem(n, q, None))
+        else:
+            n, q, pr = p
+            out.append(KitItem(n, q, pr))
+    return out
+
+
+# A minimal SRD-ish baseline; expand later as needed
+CLASS_KITS: Dict[str, list[KitItem]] = {
+    "Wizard": items(
+        ("Quarterstaff", 1),
+        ("Arcane Focus (Wand)", 1),
+        ("Component Pouch", 1),
+        ("Scholar's Pack", 1),
+        ("Spellbook", 1),
+    ),
+    "Fighter": items(
+        ("Longsword", 1),
+        ("Shield", 1, {"ac_bonus": 2}),
+        ("Chain Mail", 1, {"ac": 16}),
+        ("Explorer's Pack", 1),
+    ),
+    "Rogue": items(
+        ("Rapier", 1),
+        ("Shortbow", 1, {"ammo": "Arrows"}),
+        ("Arrows", 20),
+        ("Leather Armor", 1, {"ac": 11}),
+        ("Burglar's Pack", 1),
+        ("Thieves' Tools", 1),
+    ),
+    "Cleric": items(
+        ("Mace", 1),
+        ("Shield", 1, {"ac_bonus": 2}),
+        ("Chain Mail", 1, {"ac": 16}),
+        ("Holy Symbol", 1),
+        ("Priest's Pack", 1),
+    ),
+    # …add more classes as you like
+}
+
+BACKGROUND_KITS: Dict[str, list[KitItem]] = {
+    "Sage": items(
+        ("Ink (1 oz bottle)", 1),
+        ("Quill", 1),
+        ("Parchment", 10),
+        ("Small Knife", 1),
+    ),
+    "Soldier": items(
+        ("Insignia of Rank", 1),
+        ("Trophy from a Fallen Enemy", 1),
+        ("Set of Dice", 1),
+        ("Common Clothes", 1),
+    ),
+    "Acolyte": items(
+        ("Holy Symbol", 1),
+        ("Prayer Book", 1),
+        ("Stick of Incense", 5),
+        ("Common Clothes", 1),
+    ),
+}
+
+BACKGROUND_LANGUAGES: Dict[str, list[str]] = {
+    "Sage": ["Any"],  # choose later; we still record the slot
+    "Acolyte": ["Celestial"],
+}
+
+BACKGROUND_TOOLS: Dict[str, list[str]] = {
+    "Rogue": ["Thieves' Tools"],  # class-typical (you might keep this class-side if preferred)
+    "Soldier": ["Gaming Set (Dice)"],
+    "Guild Artisan": ["Tinker’s Tools"],
+    "Sailor": ["Navigator’s Tools", "Vehicles (Water)"],
+}

--- a/grimbrain/sheet.py
+++ b/grimbrain/sheet.py
@@ -47,6 +47,10 @@ def prof_block(pc: PlayerCharacter) -> Table:
     t.add_row("Prof.", f"+{pc.prof}")
     t.add_row("Saves", _caps_csv(pc.save_proficiencies))
     t.add_row("Skills", _caps_csv(pc.skill_proficiencies))
+    langs = ", ".join(pc.languages) if pc.languages else "—"
+    tools = ", ".join(pc.tool_proficiencies) if pc.tool_proficiencies else "—"
+    t.add_row("Languages", langs)
+    t.add_row("Tools", tools)
     return t
 
 
@@ -154,7 +158,9 @@ def to_markdown(
     out += (
         f"- **Proficiency Bonus**: +{pc.prof}\n"
         f"- **Saving Throws**: {_caps_csv(pc.save_proficiencies)}\n"
-        f"- **Skills**: {_caps_csv(pc.skill_proficiencies)}\n\n"
+        f"- **Skills**: {_caps_csv(pc.skill_proficiencies)}\n"
+        f"- **Languages**: {', '.join(pc.languages) if pc.languages else '—'}\n"
+        f"- **Tools**: {', '.join(pc.tool_proficiencies) if pc.tool_proficiencies else '—'}\n\n"
     )
     out += "## Derived\n\n"
     out += (

--- a/grimbrain/sheet_pdf.py
+++ b/grimbrain/sheet_pdf.py
@@ -70,10 +70,16 @@ def _pkg_version() -> str:
 
 
 def _profs_table(pc: PlayerCharacter) -> Table:
+    saves = _caps_csv(pc.save_proficiencies)
+    skills = _caps_csv(pc.skill_proficiencies)
+    langs = ", ".join(pc.languages) if pc.languages else "—"
+    tools = ", ".join(pc.tool_proficiencies) if pc.tool_proficiencies else "—"
     data = [
         ["Prof. Bonus", f"+{pc.prof}"],
-        ["Saves", _caps_csv(pc.save_proficiencies)],
-        ["Skills", _caps_csv(pc.skill_proficiencies)],
+        ["Saves", saves],
+        ["Skills", skills],
+        ["Languages", langs],
+        ["Tools", tools],
     ]
     t = Table(data, hAlign="LEFT")
     t.setStyle(

--- a/schema/pc.schema.json
+++ b/schema/pc.schema.json
@@ -60,7 +60,9 @@
     "save_proficiencies": {"type": "array", "items": {"type": "string"}},
     "skill_proficiencies": {"type": "array", "items": {"type": "string"}},
     "armor_proficiencies": {"type": "array", "items": {"type": "string"}},
-    "weapon_proficiencies": {"type": "array", "items": {"type": "string"}}
+    "weapon_proficiencies": {"type": "array", "items": {"type": "string"}},
+    "languages": {"type": "array", "items": {"type": "string"}},
+    "tool_proficiencies": {"type": "array", "items": {"type": "string"}}
   },
   "additionalProperties": false
 }

--- a/tests/test_equipment_packs.py
+++ b/tests/test_equipment_packs.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from pathlib import Path
+
+from grimbrain.characters import PCOptions, create_pc, apply_starter_kits
+
+
+def _wiz_opts():
+    return PCOptions(
+        name="Elora",
+        klass="Wizard",
+        race="High Elf",
+        background="Sage",
+        ac=12,
+        abilities={"str": 8, "dex": 14, "con": 12, "int": 16, "wis": 10, "cha": 12},
+    )
+
+
+def test_starter_kits_add_items_and_langs_tools(tmp_path: Path):
+    pc = create_pc(_wiz_opts())
+    apply_starter_kits(pc)
+    names = {i.name for i in pc.inventory}
+    assert "Quarterstaff" in names and "Spellbook" in names
+    # from background
+    assert any("Parchment" in i.name for i in pc.inventory)
+    # languages/tools present (Sage has a flex 'Any'; just ensure recorded)
+    assert len(pc.languages) >= 1
+    # Doesn't crash if re-applied (idempotent-ish for simple lists)
+    apply_starter_kits(pc)
+
+
+def test_cli_equip_unknown_preset_raises(tmp_path: Path, monkeypatch):
+    # Minimal PC file
+    from grimbrain.characters import save_pc
+
+    pc = create_pc(_wiz_opts())
+    p = tmp_path / "pc.json"
+    save_pc(pc, p)
+    import subprocess, sys
+
+    cp = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "grimbrain",
+            "character",
+            "equip",
+            str(p),
+            "--preset",
+            "Nope",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert cp.returncode != 0


### PR DESCRIPTION
## Summary
- add class/background equipment kits and background proficiencies
- apply starter kits and track languages and tool proficiencies
- expose `--starter` and `character equip --preset` commands; display Languages/Tools on sheets

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'reportlab')*


------
https://chatgpt.com/codex/tasks/task_e_68af62b84b6883278e875283fc87137f