### PR TITLE
PR 12.1 — Rename klass → class

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ quests:
 
 Create a level‑1 Wizard:
 ```bash
-grimbrain character create --name Elora --klass Wizard --race "High Elf" \
+grimbrain character create --name Elora --class Wizard --race "High Elf" \
   --background Sage --ac 12 --str 8 --dex 14 --con 12 --int 16 --wis 10 --cha 12 \
   --out pc_wizard.json
 ```
@@ -68,12 +68,12 @@ grimbrain character level pc_wizard.json --to 3
 
 Create with standard array assigned to INT, DEX, CON, STR, WIS, CHA:
 ```bash
-grimbrain character array --name Elora --klass Wizard \
+grimbrain character array --name Elora --class Wizard \
   --assign int,dex,con,str,wis,cha --out pc_wizard.json
 ```
 Create via point‑buy (27‑point):
 ```bash
-grimbrain character pointbuy --name Nox --klass Warlock --stats 15,14,13,10,10,8
+grimbrain character pointbuy --name Nox --class Warlock --stats 15,14,13,10,10,8
 ```
 
 Supports full casters (Wizard, Cleric, Druid, Sorcerer, Bard), half‑casters
@@ -82,12 +82,12 @@ Warlock pact magic slot rules.
 
 Create an Eldritch Knight:
 ```bash
-grimbrain character create --name Tharn --klass Fighter --subclass "Eldritch Knight" --ac 17 \
+grimbrain character create --name Tharn --class Fighter --subclass "Eldritch Knight" --ac 17 \
   --str 16 --dex 12 --con 14 --int 10 --wis 10 --cha 8 --out pc_tharn.json
 ```
 Create an Arcane Trickster:
 ```bash
-grimbrain character create --name Sable --klass Rogue --subclass "Arcane Trickster" --ac 15 \
+grimbrain character create --name Sable --class Rogue --subclass "Arcane Trickster" --ac 15 \
   --str 10 --dex 16 --con 12 --int 14 --wis 10 --cha 8 --out pc_sable.json
 ```
 
@@ -119,7 +119,7 @@ grimbrain character sheet pc_elora.json --fmt pdf --logo assets/grimbrain_logo.p
 
 Create a PC with class/background starter packs:
 ```bash
-grimbrain character create --name Elora --klass Wizard --background Sage --ac 12 \
+grimbrain character create --name Elora --class Wizard --background Sage --ac 12 \
   --str 8 --dex 14 --con 12 --int 16 --wis 10 --cha 12 --starter --out pc_elora.json
 ```
 

--- a/grimbrain/characters.py
+++ b/grimbrain/characters.py
@@ -42,7 +42,7 @@ HIT_DIE = {
 @dataclass
 class PCOptions:
     name: str
-    klass: str  # e.g., 'Wizard'
+    class_: str  # e.g., 'Wizard'
     race: str | None
     background: str | None
     abilities: dict  # {str,dex,con,int,wis,cha}
@@ -55,12 +55,12 @@ class PCOptions:
 
 def create_pc(opts: PCOptions) -> PlayerCharacter:
     abilities = Abilities(**opts.abilities)
-    hd = HIT_DIE.get(opts.klass, 8)
+    hd = HIT_DIE.get(opts.class_, 8)
     con_mod = abilities.modifier("con")
     max_hp = hd + con_mod  # L1 max per 5e baseline
     pc = PlayerCharacter(
         name=opts.name,
-        **{"class": opts.klass},
+        **{"class": opts.class_},
         race=opts.race,
         background=opts.background,
         subclass=opts.subclass,
@@ -69,9 +69,9 @@ def create_pc(opts: PCOptions) -> PlayerCharacter:
         ac=opts.ac,
         max_hp=max_hp,
         current_hp=max_hp,
-        spell_slots=_spell_slots_for(opts.klass, 1, opts.subclass),
+        spell_slots=_spell_slots_for(opts.class_, 1, opts.subclass),
     )
-    pc.save_proficiencies = CLASS_SAVE_PROFS.get(opts.klass, set())
+    pc.save_proficiencies = CLASS_SAVE_PROFS.get(opts.class_, set())
     if opts.background:
         pc.skill_proficiencies = BACKGROUND_SKILLS.get(opts.background, set())
     return pc

--- a/grimbrain/cli_character.py
+++ b/grimbrain/cli_character.py
@@ -23,7 +23,7 @@ char_app = typer.Typer(help="Character creation and management")
 @char_app.command("create")
 def create(
     name: str = typer.Option(...),
-    klass: str = typer.Option(..., help="Class, e.g. Wizard"),
+    class_: str = typer.Option(..., "--class", help="Class, e.g. Wizard"),
     subclass: str = typer.Option(None, help="Subclass (for EK/AT etc.)"),
     race: str = typer.Option(None),
     background: str = typer.Option(None),
@@ -41,7 +41,7 @@ def create(
 ):
     opts = PCOptions(
         name=name,
-        klass=klass,
+        class_=class_,
         subclass=subclass,
         race=race,
         background=background,
@@ -65,7 +65,7 @@ def create(
 @char_app.command("array")
 def make_from_array(
     name: str = typer.Option(...),
-    klass: str = typer.Option(...),
+    class_: str = typer.Option(..., "--class"),
     subclass: str = typer.Option(None, help="Subclass"),
     race: str = typer.Option(None),
     background: str = typer.Option(None),
@@ -86,7 +86,7 @@ def make_from_array(
     abilities = dict(zip(keys, vals))
     opts = PCOptions(
         name=name,
-        klass=klass,
+        class_=class_,
         subclass=subclass,
         race=race,
         background=background,
@@ -103,7 +103,7 @@ def make_from_array(
 @char_app.command("pointbuy")
 def make_from_pointbuy(
     name: str = typer.Option(...),
-    klass: str = typer.Option(...),
+    class_: str = typer.Option(..., "--class"),
     subclass: str = typer.Option(None, help="Subclass"),
     race: str = typer.Option(None),
     background: str = typer.Option(None),
@@ -123,7 +123,7 @@ def make_from_pointbuy(
         raise typer.BadParameter(f"Point-buy total {pb.cost} exceeds 27")
     opts = PCOptions(
         name=name,
-        klass=klass,
+        class_=class_,
         subclass=subclass,
         race=race,
         background=background,

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -4,7 +4,7 @@ from grimbrain.characters import PCOptions, add_item, create_pc, learn_spell, le
 def test_create_and_level():
     opts = PCOptions(
         name="Elora",
-        klass="Wizard",
+        class_="Wizard",
         race="High Elf",
         background="Sage",
         ac=12,

--- a/tests/test_character_derived.py
+++ b/tests/test_character_derived.py
@@ -4,7 +4,7 @@ from grimbrain.characters import PCOptions, create_pc
 def _wiz():
     return PCOptions(
         name="Elora",
-        klass="Wizard",
+        class_="Wizard",
         race="High Elf",
         background="Sage",
         ac=12,

--- a/tests/test_equipment_packs.py
+++ b/tests/test_equipment_packs.py
@@ -8,7 +8,7 @@ from grimbrain.characters import PCOptions, create_pc, apply_starter_kits
 def _wiz_opts():
     return PCOptions(
         name="Elora",
-        klass="Wizard",
+        class_="Wizard",
         race="High Elf",
         background="Sage",
         ac=12,

--- a/tests/test_save_and_schema_roundtrip.py
+++ b/tests/test_save_and_schema_roundtrip.py
@@ -9,7 +9,7 @@ def test_roundtrip_pc_json(tmp_path: Path) -> None:
     pc = create_pc(
         PCOptions(
             name="Elora",
-            klass="Wizard",
+            class_="Wizard",
             race="High Elf",
             background="Sage",
             ac=12,

--- a/tests/test_sheet_markdown.py
+++ b/tests/test_sheet_markdown.py
@@ -8,7 +8,7 @@ def test_sheet_md_contains_core_fields(tmp_path: Path):
     pc = create_pc(
         PCOptions(
             name="Elora",
-            klass="Wizard",
+            class_="Wizard",
             race="High Elf",
             background="Sage",
             ac=12,

--- a/tests/test_sheet_pdf.py
+++ b/tests/test_sheet_pdf.py
@@ -8,7 +8,7 @@ def test_pdf_written(tmp_path: Path):
     pc = create_pc(
         PCOptions(
             name="Elora",
-            klass="Wizard",
+            class_="Wizard",
             race="High Elf",
             background="Sage",
             ac=12,

--- a/tests/test_sheet_polish.py
+++ b/tests/test_sheet_polish.py
@@ -15,7 +15,7 @@ def _pc():
     return create_pc(
         PCOptions(
             name="Elora",
-            klass="Wizard",
+            class_="Wizard",
             race="High Elf",
             background="Sage",
             ac=12,

--- a/tests/test_slots_progressions.py
+++ b/tests/test_slots_progressions.py
@@ -1,9 +1,9 @@
 from grimbrain.characters import PCOptions, create_pc, level_up
 
 
-def _opts(klass, subclass=None):
+def _opts(class_, subclass=None):
     return PCOptions(
-        name="Test", klass=klass, subclass=subclass, race=None, background=None, ac=12,
+        name="Test", class_=class_, subclass=subclass, race=None, background=None, ac=12,
         abilities={"str":10,"dex":10,"con":10,"int":10,"wis":10,"cha":10}
     )
 


### PR DESCRIPTION
## Summary
- refactor PCOptions to use `class_` field instead of `klass`
- switch CLI flags to `--class`
- update tests for renamed PCOptions field

## Testing
- `pytest` *(fails: Coverage failure: total of 36 is less than fail-under=70)*
- `pytest --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68b04806f9448327bf76fc85e1833e60