### PR TITLE
PR 13 — Spellbook (learn/prepare), Casting, and Rest Mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,28 @@ grimbrain character equip pc_elora.json --preset Sage
 
 Sheets will now list Languages and Tools under Proficiencies.
 
+### Spells & Casting
+
+Learn and prepare:
+```bash
+grimbrain character learn pc_elora.json --spell "Magic Missile"
+grimbrain character prepare pc_elora.json --spell "Magic Missile"
+```
+
+Casting & rest:
+
+```bash
+grimbrain character cast pc_elora.json --level 1
+grimbrain character rest pc_elora.json --type long
+```
+
+Get spell stats:
+
+```bash
+grimbrain character spellstats pc_elora.json
+# → Spell Save DC: 13 | Spell Attack: +5
+```
+
 ## Python API
 ```python
 from grimbrain.retrieval.query_router import run_query

--- a/grimbrain/models/pc.py
+++ b/grimbrain/models/pc.py
@@ -73,7 +73,8 @@ class PlayerCharacter(BaseModel):
     max_hp: PositiveInt
     current_hp: Optional[int] = None
     inventory: List[Item] = []
-    spells: List[str] = []
+    known_spells: List[str] = []       # stable storage for “you know these”
+    prepared_spells: List[str] = []    # subset eligible to cast (for prepared casters)
     spell_slots: SpellSlots | None = None
 
     # Proficiencies

--- a/grimbrain/rules_spells.py
+++ b/grimbrain/rules_spells.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from typing import Dict, List
+
+# Minimal SRD-ish seed lists; expand freely later.
+SPELLS_BY_CLASS: Dict[str, Dict[int, List[str]]] = {
+    "Wizard": {
+        0: ["Prestidigitation", "Mage Hand"],
+        1: ["Magic Missile", "Shield", "Detect Magic"],
+        2: ["Misty Step", "Mirror Image"],
+    },
+    "Cleric": {
+        0: ["Guidance", "Sacred Flame"],
+        1: ["Cure Wounds", "Bless"],
+    },
+    "Warlock": {
+        0: ["Eldritch Blast"],
+        1: ["Hex", "Armor of Agathys"],
+        2: ["Invisibility"],
+    },
+    # add more as needed (Druid, Bard, Sorcerer, etc.)
+}
+
+CASTING_ABILITY: Dict[str, str] = {
+    "Wizard": "int",
+    "Cleric": "wis",
+    "Druid": "wis",
+    "Bard": "cha",
+    "Sorcerer": "cha",
+    "Warlock": "cha",
+    "Paladin": "cha",
+    "Ranger": "wis",
+    # EK/AT still use int for their spells typically; handled via subclass if desired
+}
+
+# Prepared-caster classes vs known-caster classes (baseline SRD assumption)
+PREPARED_CASTER = {"Cleric", "Druid", "Paladin", "Wizard"}  # Wizards technically prepare from a spellbook
+KNOWN_CASTER = {"Bard", "Sorcerer", "Warlock", "Ranger"}     # (Ranger prepares in 5e; feel free to move it)

--- a/grimbrain/sheet_pdf.py
+++ b/grimbrain/sheet_pdf.py
@@ -108,6 +108,27 @@ def _defense_table(pc: PlayerCharacter) -> Table:
     return t
 
 
+def _spell_stats_table(pc: PlayerCharacter) -> Table:
+    from grimbrain.characters import spell_save_dc, spell_attack_bonus
+
+    dc = spell_save_dc(pc)
+    atk = spell_attack_bonus(pc)
+    rows = []
+    if dc is not None and atk is not None:
+        rows.append(["Spell Save DC", str(dc)])
+        rows.append(["Spell Attack", f"+{atk}"])
+    else:
+        rows.append(["Spellcasting", "—"])
+    t = Table(rows, hAlign='LEFT')
+    t.setStyle(TableStyle([
+        ('FONT', (0,0), (-1,-1), 'Helvetica', NORMAL),
+        ('GRID', (0,0), (-1,-1), 0.25, colors.lightgrey),
+        ('BACKGROUND', (0,0), (-1,0), colors.whitesmoke),
+        ('FONT', (0,0), (-1,0), 'Helvetica-Bold', NORMAL),
+    ]))
+    return t
+
+
 def _slots_table(pc: PlayerCharacter, show_zero: bool) -> Table:
     data = [["Slots", _slots_line(pc, show_zero)]]
     t = Table(data, hAlign="LEFT")
@@ -121,6 +142,18 @@ def _slots_table(pc: PlayerCharacter, show_zero: bool) -> Table:
             ]
         )
     )
+    return t
+
+
+def _prepared_table(pc: PlayerCharacter) -> Table:
+    items = ", ".join(pc.prepared_spells) if pc.prepared_spells else "—"
+    t = Table([["Prepared", items]], hAlign='LEFT')
+    t.setStyle(TableStyle([
+        ('FONT', (0,0), (-1,-1), 'Helvetica', NORMAL),
+        ('GRID', (0,0), (-1,-1), 0.25, colors.lightgrey),
+        ('BACKGROUND', (0,0), (-1,0), colors.whitesmoke),
+        ('FONT', (0,0), (-1,0), 'Helvetica-Bold', NORMAL),
+    ]))
     return t
 
 
@@ -185,10 +218,10 @@ def save_pdf(
     ]
     right = [
         Paragraph("<b>Spellcasting</b>", styles["Heading3"]),
-        _slots_table(pc, show_zero_slots),
-        Spacer(1, 0.12 * inch),
-        Paragraph("<b>Inventory</b>", styles["Heading3"]),
-        _inventory_table(pc),
+        _spell_stats_table(pc), Spacer(1, 0.08 * inch),
+        _slots_table(pc, show_zero_slots), Spacer(1, 0.08 * inch),
+        _prepared_table(pc), Spacer(1, 0.12 * inch),
+        Paragraph("<b>Inventory</b>", styles["Heading3"]), _inventory_table(pc)
     ]
 
     col_width = 3.4 * inch

--- a/grimbrain/validation.py
+++ b/grimbrain/validation.py
@@ -45,11 +45,20 @@ def _validate_jsonschema(obj: Any, schema_path: Path) -> None:
         raise PrettyError("JSON Schema validation failed:\n" + "\n".join(lines) + more)
 
 
+def _migrate_spells_legacy(data: dict) -> dict:
+    if "spells" in data and "known_spells" not in data:
+        if isinstance(data["spells"], list):
+            data["known_spells"] = list(dict.fromkeys(data["spells"]))
+        del data["spells"]
+    return data
+
+
 # Public API
 
 
 def load_pc(path: Path) -> PlayerCharacter:
     data = _read_json(path)
+    data = _migrate_spells_legacy(data)
     _validate_jsonschema(data, _def_schemas["pc"])
     try:
         return PlayerCharacter.model_validate(data)

--- a/schema/pc.schema.json
+++ b/schema/pc.schema.json
@@ -41,7 +41,8 @@
         "additionalProperties": false
       }
     },
-    "spells": {"type": "array", "items": {"type": "string"}},
+    "known_spells": {"type": "array", "items": {"type": "string"}},
+    "prepared_spells": {"type": "array", "items": {"type": "string"}},
     "spell_slots": {
       "type": "object",
       "properties": {

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -21,4 +21,4 @@ def test_create_and_level():
     add_item(pc2, "Potion of Healing", 1)
     learn_spell(pc2, "Magic Missile")
     assert any(i.name == "Potion of Healing" for i in pc2.inventory)
-    assert "Magic Missile" in pc2.spells
+    assert "Magic Missile" in pc2.known_spells

--- a/tests/test_spellcasting.py
+++ b/tests/test_spellcasting.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import pytest
+from grimbrain.characters import PCOptions, create_pc, save_pc, load_pc
+from grimbrain.characters import learn_spell, prepare_spell, cast_slot, long_rest
+from grimbrain.characters import spell_save_dc, spell_attack_bonus
+
+
+def _wiz():
+    return PCOptions(
+        name="Elora", class_="Wizard", race="High Elf", background="Sage", ac=12,
+        abilities={"str":8,"dex":14,"con":12,"int":16,"wis":10,"cha":12}
+    )
+
+def test_dc_and_attack_bonus():
+    pc = create_pc(_wiz())
+    assert spell_save_dc(pc) == 8 + pc.prof + pc.ability_mod("int")
+    assert spell_attack_bonus(pc) == pc.prof + pc.ability_mod("int")
+
+def test_learn_prepare_and_cast(tmp_path: Path):
+    pc = create_pc(_wiz())
+    learn_spell(pc, "Magic Missile")
+    prepare_spell(pc, "Magic Missile")  # Wizard allowed
+    # Give some slots
+    assert pc.spell_slots and pc.spell_slots.l1 >= 2
+    before = pc.spell_slots.l1
+    cast_slot(pc, 1)
+    assert pc.spell_slots.l1 == before - 1
+    long_rest(pc)
+    assert pc.spell_slots.l1 >= 2  # restored
+
+def test_prepare_unknown_raises():
+    pc = create_pc(_wiz())
+    with pytest.raises(ValueError):
+        prepare_spell(pc, "Shield")  # not learned


### PR DESCRIPTION
## Summary
- track known and prepared spells with spellcasting stats and rest mechanics
- expand character CLI with learn, prepare, cast, rest, and spellstats commands
- surface spell DC/attack and prepared list on sheets
- migrate legacy `spells` field to new `known_spells` schema
- test spellcasting flows and slot restoration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b05662ec3c8327b70b8cd1b8e9b34c