### PR TITLE
feat: add weapons and attack rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ grimbrain character spellstats pc_elora.json
 # → Spell Save DC: 13 | Spell Attack: +5
 ```
 
+### Weapons & Attacks
+
+Weapons are defined in `data/weapons.json`. Equip a weapon by adding its
+name to a character's `equipped_weapons` list and ensuring the matching
+proficiency is present. Equipped weapons appear under **Attacks &
+Spellcasting** on rendered sheets.
+
 ## Python API
 ```python
 from grimbrain.retrieval.query_router import run_query

--- a/data/weapons.json
+++ b/data/weapons.json
@@ -1,16 +1,66 @@
 [
   {
-    "name": "Shortsword",
-    "range": "melee",
-    "properties": ["finesse"],
-    "damage_dice": "1d6",
-    "damage_type": "slashing"
+    "name": "Dagger",
+    "category": "simple",
+    "kind": "melee",
+    "damage": "1d4",
+    "damage_type": "piercing",
+    "properties": ["finesse", "light", "thrown", "range:20/60"]
+  },
+  {
+    "name": "Rapier",
+    "category": "martial",
+    "kind": "melee",
+    "damage": "1d8",
+    "damage_type": "piercing",
+    "properties": ["finesse"]
+  },
+  {
+    "name": "Longsword",
+    "category": "martial",
+    "kind": "melee",
+    "damage": "1d8",
+    "damage_type": "slashing",
+    "properties": ["versatile:1d10"]
+  },
+  {
+    "name": "Greatsword",
+    "category": "martial",
+    "kind": "melee",
+    "damage": "2d6",
+    "damage_type": "slashing",
+    "properties": ["heavy", "two-handed"]
   },
   {
     "name": "Shortbow",
-    "range": "ranged",
-    "properties": [],
-    "damage_dice": "1d6",
-    "damage_type": "piercing"
+    "category": "simple",
+    "kind": "ranged",
+    "damage": "1d6",
+    "damage_type": "piercing",
+    "properties": ["ammunition", "two-handed", "range:80/320"]
+  },
+  {
+    "name": "Longbow",
+    "category": "martial",
+    "kind": "ranged",
+    "damage": "1d8",
+    "damage_type": "piercing",
+    "properties": ["ammunition", "heavy", "two-handed", "range:150/600"]
+  },
+  {
+    "name": "Handaxe",
+    "category": "simple",
+    "kind": "melee",
+    "damage": "1d6",
+    "damage_type": "slashing",
+    "properties": ["light", "thrown", "range:20/60"]
+  },
+  {
+    "name": "Mace",
+    "category": "simple",
+    "kind": "melee",
+    "damage": "1d6",
+    "damage_type": "bludgeoning",
+    "properties": []
   }
 ]

--- a/grimbrain/codex/__init__.py
+++ b/grimbrain/codex/__init__.py
@@ -1,0 +1,5 @@
+"""Reference data loaders for SRD content."""
+
+from .weapons import Weapon, WeaponIndex  # noqa: F401
+
+__all__ = ["Weapon", "WeaponIndex"]

--- a/grimbrain/codex/weapons.py
+++ b/grimbrain/codex/weapons.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from typing import List, Dict, Optional
+import json
+import re
+from pathlib import Path
+
+@dataclass(frozen=True)
+class Weapon:
+    name: str
+    category: str           # "simple" | "martial"
+    kind: str               # "melee" | "ranged"
+    damage: str             # "1d6" etc.
+    damage_type: str        # "slashing" | "piercing" | "bludgeoning"
+    properties: List[str]   # e.g., ["finesse", "versatile:1d10", "range:20/60"]
+
+    def has_prop(self, key: str) -> bool:
+        return any(p.split(":")[0] == key for p in self.properties)
+
+    def get_prop_value(self, key: str) -> Optional[str]:
+        for p in self.properties:
+            k, *rest = p.split(":")
+            if k == key and rest:
+                return rest[0]
+        return None
+
+    def versatile_die(self) -> Optional[str]:
+        return self.get_prop_value("versatile")
+
+    def range_tuple(self) -> Optional[tuple]:
+        val = self.get_prop_value("range")
+        if not val:
+            return None
+        m = re.match(r"(\d+)\/(\d+)", val)
+        return (int(m.group(1)), int(m.group(2))) if m else None
+
+
+class WeaponIndex:
+    def __init__(self, weapons: Dict[str, Weapon]):
+        self.by_name = weapons
+
+    @classmethod
+    def load(cls, path: Path) -> "WeaponIndex":
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        weapons = {}
+        for w in raw:
+            weapon = Weapon(**w)
+            weapons[weapon.name.lower()] = weapon
+        return cls(weapons)
+
+    def get(self, name: str) -> Weapon:
+        return self.by_name[name.lower()]

--- a/grimbrain/models/pc.py
+++ b/grimbrain/models/pc.py
@@ -84,6 +84,7 @@ class PlayerCharacter(BaseModel):
     weapon_proficiencies: Set[str] = set()
     languages: List[str] = []
     tool_proficiencies: List[str] = []
+    equipped_weapons: List[str] = []
 
     class Config:
         populate_by_name = True
@@ -98,7 +99,7 @@ class PlayerCharacter(BaseModel):
         return 2 + ((lvl - 1) // 4)
 
     def ability_mod(self, name: str) -> int:
-        return self.abilities.modifier(name)
+        return self.abilities.modifier(name.lower())
 
     def skill_mod(self, skill: str) -> int:
         key = {
@@ -139,6 +140,12 @@ class PlayerCharacter(BaseModel):
     @property
     def passive_perception(self) -> int:
         return 10 + self.skill_mod("perception")
+
+    # --- Attacks ---
+    def attacks(self, weapon_index) -> List[dict]:
+        from grimbrain.rules.attacks import build_attacks_block
+
+        return build_attacks_block(self, weapon_index)
 
     def attack_bonus(self, ability: str, proficient: bool) -> int:
         return self.ability_mod(ability) + (self.prof if proficient else 0)

--- a/grimbrain/rules/attacks.py
+++ b/grimbrain/rules/attacks.py
@@ -1,0 +1,84 @@
+from typing import List
+from ..codex.weapons import Weapon
+
+# Expect character to expose:
+#   ability_mod("STR"/"DEX"), prof or proficiency_bonus, weapon_proficiencies or proficiencies
+#   equipped_weapons: list[str]
+
+
+def _pb(character) -> int:
+    pb = getattr(character, "proficiency_bonus", None)
+    if pb is None:
+        pb = getattr(character, "prof", 0)
+    return pb
+
+
+def format_mod(n: int) -> str:
+    return f"+{n}" if n >= 0 else str(n)
+
+
+def choose_attack_ability(character, weapon: Weapon) -> str:
+    # Ranged weapons use DEX
+    if weapon.kind == "ranged":
+        return "DEX"
+    # Thrown uses STR unless finesse also present
+    if weapon.has_prop("thrown") and weapon.has_prop("finesse"):
+        return "DEX" if character.ability_mod("DEX") >= character.ability_mod("STR") else "STR"
+    if weapon.has_prop("thrown"):
+        return "STR"
+    # Melee: STR unless finesse; pick higher if finesse
+    if weapon.has_prop("finesse"):
+        return "DEX" if character.ability_mod("DEX") >= character.ability_mod("STR") else "STR"
+    return "STR"
+
+
+def is_proficient(character, weapon: Weapon) -> bool:
+    profs = {p.lower() for p in getattr(character, "proficiencies", getattr(character, "weapon_proficiencies", set()))}
+    return (
+        f"{weapon.category} weapons" in profs or
+        weapon.name.lower() in profs
+    )
+
+
+def attack_bonus(character, weapon: Weapon) -> int:
+    ability = choose_attack_ability(character, weapon)
+    bonus = character.ability_mod(ability)
+    if is_proficient(character, weapon):
+        bonus += _pb(character)
+    return bonus
+
+
+def damage_die(character, weapon: Weapon, *, two_handed: bool=False) -> str:
+    die = weapon.damage
+    v = weapon.versatile_die()
+    if v and two_handed:
+        die = v
+    return die
+
+
+def damage_modifier(character, weapon: Weapon, *, two_handed: bool=False) -> int:
+    ability = choose_attack_ability(character, weapon)
+    return character.ability_mod(ability)
+
+
+def damage_string(character, weapon: Weapon, *, two_handed: bool=False) -> str:
+    die = damage_die(character, weapon, two_handed=two_handed)
+    mod = damage_modifier(character, weapon, two_handed=two_handed)
+    mod_str = format_mod(mod) if mod != 0 else ""
+    return f"{die}{(' ' + mod_str) if mod_str else ''} {weapon.damage_type}"
+
+
+def build_attacks_block(character, weapon_index) -> List[dict]:
+    out = []
+    for name in getattr(character, "equipped_weapons", []):
+        w = weapon_index.get(name)
+        ab = attack_bonus(character, w)
+        dmg = damage_string(character, w, two_handed=False)
+        props = ", ".join(w.properties) if w.properties else ""
+        out.append({
+            "name": w.name,
+            "attack_bonus": ab,
+            "damage": dmg,
+            "properties": props
+        })
+    return out

--- a/tests/golden/attacks_block.golden
+++ b/tests/golden/attacks_block.golden
@@ -1,0 +1,2 @@
+- Longsword: +5 to hit, 1d8 +3 slashing (versatile:1d10)
+- Dagger: +5 to hit, 1d4 +3 piercing (finesse, light, thrown, range:20/60)

--- a/tests/golden/burning_pretty.golden
+++ b/tests/golden/burning_pretty.golden
@@ -1,5 +1,4 @@
 Conflict: rule/attack.shortbow -> keeping generated, ignoring legacy-data
-Conflict: rule/attack.shortsword -> keeping generated, ignoring legacy-data
 Effect on Hero begins
 Hero ignites Hero (burning)
 Hero starts burning

--- a/tests/golden/hide_full_pretty.golden
+++ b/tests/golden/hide_full_pretty.golden
@@ -1,5 +1,4 @@
 Conflict: rule/attack.shortbow -> keeping generated, ignoring legacy-data
-Conflict: rule/attack.shortsword -> keeping generated, ignoring legacy-data
 Not found verb: "hide"
 Not found verb: "status"
 Not found verb: "end"

--- a/tests/test_attacks_block.py
+++ b/tests/test_attacks_block.py
@@ -1,0 +1,40 @@
+import os
+from pathlib import Path
+from grimbrain.characters import PCOptions, create_pc
+from grimbrain.sheet import to_markdown
+
+
+def extract_block(md: str) -> str:
+    lines = []
+    in_block = False
+    for line in md.splitlines():
+        if line.startswith("## Attacks & Spellcasting"):
+            in_block = True
+            continue
+        if in_block and line.startswith("## "):
+            break
+        if in_block:
+            lines.append(line)
+    return "\n".join(l for l in lines if l).strip() + "\n"
+
+
+def test_attacks_block_golden():
+    pc = create_pc(
+        PCOptions(
+            name="Aragorn",
+            class_="Fighter",
+            race="Human",
+            background=None,
+            ac=16,
+            abilities={"str": 16, "dex": 14, "con": 14, "int": 10, "wis": 12, "cha": 12},
+        )
+    )
+    pc.weapon_proficiencies = {"martial weapons", "simple weapons"}
+    pc.equipped_weapons = ["Longsword", "Dagger"]
+    md = to_markdown(pc)
+    got = extract_block(md)
+    golden = Path("tests/golden/attacks_block.golden")
+    if os.environ.get("UPDATE_GOLDEN"):
+        golden.write_text(got, encoding="utf-8")
+    want = golden.read_text(encoding="utf-8")
+    assert got == want

--- a/tests/test_sheet_markdown.py
+++ b/tests/test_sheet_markdown.py
@@ -15,9 +15,12 @@ def test_sheet_md_contains_core_fields(tmp_path: Path):
             abilities={"str": 8, "dex": 14, "con": 12, "int": 16, "wis": 10, "cha": 12},
         )
     )
+    pc.weapon_proficiencies.add("simple weapons")
+    pc.equipped_weapons.append("Dagger")
     md = to_markdown(pc)
     assert "# Elora" in md
     assert "**Class:** Wizard" in md
     assert "## Abilities" in md and "**INT**" in md
     assert "## Proficiencies" in md and "Proficiency Bonus" in md
+    assert "## Attacks & Spellcasting" in md
     assert "## Spellcasting" in md

--- a/tests/test_weapons.py
+++ b/tests/test_weapons.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+from grimbrain.codex.weapons import WeaponIndex
+from grimbrain.rules.attacks import attack_bonus, damage_string, choose_attack_ability
+
+
+class DummyChar:
+    def __init__(self, str_score=16, dex_score=14, pb=2, profs=None):
+        self.str_score = str_score
+        self.dex_score = dex_score
+        self.proficiency_bonus = pb
+        self.proficiencies = profs or set()
+
+    def ability_mod(self, k):
+        score = {"STR": self.str_score, "DEX": self.dex_score}[k]
+        return (score - 10) // 2
+
+
+def load_idx():
+    return WeaponIndex.load(Path("data/weapons.json"))
+
+
+def test_load_weapons():
+    idx = load_idx()
+    assert idx.get("dagger").damage == "1d4"
+
+
+def test_finesse_picks_higher_mod():
+    idx = load_idx()
+    c = DummyChar(str_score=12, dex_score=18, profs={"rapier"})
+    w = idx.get("rapier")
+    assert choose_attack_ability(c, w) == "DEX"
+    assert attack_bonus(c, w) == (4 + 2)
+
+
+def test_ranged_uses_dex():
+    idx = load_idx()
+    c = DummyChar(str_score=18, dex_score=14, profs={"shortbow", "simple weapons"})
+    w = idx.get("shortbow")
+    assert choose_attack_ability(c, w) == "DEX"
+    assert attack_bonus(c, w) == (2 + 2)
+    assert damage_string(c, w) == "1d6 +2 piercing"
+
+
+def test_thrown_defaults_str():
+    idx = load_idx()
+    c = DummyChar(str_score=16, dex_score=18, profs={"handaxe", "simple weapons"})
+    w = idx.get("handaxe")
+    assert choose_attack_ability(c, w) == "STR"
+    assert attack_bonus(c, w) == (3 + 2)
+    assert damage_string(c, w) == "1d6 +3 slashing"
+
+
+def test_thrown_finesse_allows_dex():
+    idx = load_idx()
+    c = DummyChar(str_score=12, dex_score=18, profs={"dagger", "simple weapons"})
+    w = idx.get("dagger")
+    assert choose_attack_ability(c, w) == "DEX"
+    assert attack_bonus(c, w) == (4 + 2)
+    assert damage_string(c, w) == "1d4 +4 piercing"
+
+
+def test_martial_no_proficiency():
+    idx = load_idx()
+    c = DummyChar(str_score=16, dex_score=14, profs={"simple weapons"})
+    w = idx.get("longsword")
+    assert attack_bonus(c, w) == 3
+    assert damage_string(c, w) == "1d8 +3 slashing"
+
+
+def test_versatile_two_handed_flag():
+    idx = load_idx()
+    from grimbrain.rules.attacks import damage_string as dmg, damage_die
+    c = DummyChar(str_score=16, dex_score=10, profs={"longsword", "martial weapons"})
+    w = idx.get("longsword")
+    assert damage_die(c, w, two_handed=False) == "1d8"
+    assert damage_die(c, w, two_handed=True) == "1d10"
+    assert dmg(c, w, two_handed=True) == "1d10 +3 slashing"


### PR DESCRIPTION
## Summary
- add SRD weapon reference data and codex loader
- compute attack ability, proficiency, and damage strings for weapons
- show equipped weapon attacks on character sheets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0708be23c83279ad83f6f02aa7026