### PR TITLE
Add off-hand attack handling with Two-Weapon Fighting

### DIFF
--- a/grimbrain/characters.py
+++ b/grimbrain/characters.py
@@ -293,6 +293,7 @@ def save_pc(pc: PlayerCharacter, path: Path) -> None:
         "skill_proficiencies",
         "armor_proficiencies",
         "weapon_proficiencies",
+        "fighting_styles",
     ):
         if isinstance(data.get(k), set):
             data[k] = sorted(list(data[k]))

--- a/grimbrain/models/pc.py
+++ b/grimbrain/models/pc.py
@@ -85,6 +85,8 @@ class PlayerCharacter(BaseModel):
     languages: List[str] = []
     tool_proficiencies: List[str] = []
     equipped_weapons: List[str] = []
+    fighting_styles: Set[str] = set()
+    equipped_offhand: Optional[str] = None
 
     class Config:
         populate_by_name = True

--- a/schema/pc.schema.json
+++ b/schema/pc.schema.json
@@ -64,7 +64,9 @@
     "weapon_proficiencies": {"type": "array", "items": {"type": "string"}},
     "languages": {"type": "array", "items": {"type": "string"}},
     "tool_proficiencies": {"type": "array", "items": {"type": "string"}},
-    "equipped_weapons": {"type": "array", "items": {"type": "string"}}
+    "equipped_weapons": {"type": "array", "items": {"type": "string"}},
+    "equipped_offhand": {"type": "string"},
+    "fighting_styles": {"type": "array", "items": {"type": "string"}}
   },
   "additionalProperties": false
 }

--- a/tests/test_two_weapon.py
+++ b/tests/test_two_weapon.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from grimbrain.codex.weapons import WeaponIndex
+from grimbrain.rules.attacks import damage_string, attack_bonus
+
+
+class C:
+    def __init__(self, str_=16, dex=16, pb=2, styles=None):
+        self.str_score = str_
+        self.dex_score = dex
+        self.proficiency_bonus = pb
+        self.fighting_styles = styles or set()
+        self.proficiencies = {"martial weapons", "simple weapons"}
+
+    def ability_mod(self, k):
+        return ({"STR": self.str_score, "DEX": self.dex_score}[k] - 10) // 2
+
+
+def test_offhand_no_style_suppresses_mod():
+    idx = WeaponIndex.load(Path("data/weapons.json"))
+    c = C()
+    w = idx.get("dagger")  # light, finesse
+    # primary
+    assert " +3 " in damage_string(c, w)
+    # off-hand (no style)
+    assert " +3 " not in damage_string(c, w, offhand=True)
+
+
+def test_offhand_with_style_restores_mod():
+    idx = WeaponIndex.load(Path("data/weapons.json"))
+    c = C(styles={"Two-Weapon Fighting"})
+    w = idx.get("handaxe")
+    assert " +3 " in damage_string(c, w, offhand=True)
+
+
+def test_attack_bonus_unchanged_for_offhand():
+    idx = WeaponIndex.load(Path("data/weapons.json"))
+    c = C()
+    w = idx.get("dagger")
+    ab = attack_bonus(c, w)
+    assert isinstance(ab, int)
+


### PR DESCRIPTION
## Summary
- allow `PlayerCharacter` to track fighting styles and an off-hand weapon
- suppress ability mod to off-hand damage unless Two-Weapon Fighting style
- render secondary off-hand attack lines when a valid off-hand weapon is equipped
- serialize fighting styles when saving a character
- allow fighting styles and an off-hand slot in the PC JSON schema

## Testing
- `pytest tests/test_two_weapon.py -v --no-cov`
- `pytest tests/test_equipment_packs.py::test_cli_equip_unknown_preset_raises -q --no-cov`
- `pytest tests/test_save_and_schema_roundtrip.py::test_roundtrip_pc_json -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b1a73eeec88327a2883d26d94bfcd2