### PR TITLE
Add ammunition tracking and display

### DIFF
--- a/data/weapons.json
+++ b/data/weapons.json
@@ -48,6 +48,22 @@
     "properties": ["ammunition", "heavy", "two-handed", "range:150/600"]
   },
   {
+    "name": "Hand Crossbow",
+    "category": "martial",
+    "kind": "ranged",
+    "damage": "1d6",
+    "damage_type": "piercing",
+    "properties": ["ammunition", "light", "loading", "range:30/120"]
+  },
+  {
+    "name": "Blowgun",
+    "category": "martial",
+    "kind": "ranged",
+    "damage": "1",
+    "damage_type": "piercing",
+    "properties": ["ammunition", "loading", "range:25/100"]
+  },
+  {
     "name": "Handaxe",
     "category": "simple",
     "kind": "melee",

--- a/grimbrain/character.py
+++ b/grimbrain/character.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+
+@dataclass
+class Character:
+    """Minimal character model used for attack calculations."""
+
+    str_score: int = 10
+    dex_score: int = 10
+    proficiencies: Set[str] = field(default_factory=set)
+    proficiency_bonus: int = 2
+    fighting_styles: Set[str] = field(default_factory=set)
+    equipped_weapons: List[str] = field(default_factory=list)
+    equipped_offhand: Optional[str] = None
+    ammo: Dict[str, int] = field(default_factory=dict)
+
+    def ability_mod(self, key: str) -> int:
+        score = {"STR": self.str_score, "DEX": self.dex_score}[key]
+        return (score - 10) // 2
+
+    # Ammo helpers
+    def ammo_count(self, ammo_type: str) -> int:
+        return int(self.ammo.get(ammo_type, 0))
+
+    def add_ammo(self, ammo_type: str, amount: int) -> None:
+        self.ammo[ammo_type] = self.ammo_count(ammo_type) + max(0, amount)
+
+    def spend_ammo(self, ammo_type: str, amount: int = 1) -> bool:
+        have = self.ammo_count(ammo_type)
+        if have < amount:
+            return False
+        self.ammo[ammo_type] = have - amount
+        return True
+
+    def attacks_and_spellcasting(self, weapon_index) -> List[dict]:
+        from .rules.attacks import build_attacks_block
+
+        return build_attacks_block(self, weapon_index)
+

--- a/grimbrain/codex/weapons.py
+++ b/grimbrain/codex/weapons.py
@@ -4,6 +4,54 @@ import json
 import re
 from pathlib import Path
 
+# Allowed weapon property keys
+_ALLOWED_PROP_KEYS = {
+    "finesse",
+    "light",
+    "heavy",
+    "two-handed",
+    "reach",
+    "loading",
+    "ammunition",
+    "thrown",
+    "special",
+    "range",
+    "versatile",
+    "ammo",
+}
+
+# Recognised ammunition types for explicit overrides
+_ALLOWED_AMMO_TYPES = {"arrows", "bolts", "stones", "needles"}
+
+_VERSATILE_VAL_PAT = re.compile(r"^\d+d\d+$")
+
+
+def _range_ok(val: str) -> bool:
+    try:
+        a, b = (int(x) for x in val.split("/", 1))
+    except Exception:
+        return False
+    return a > 0 and b >= a
+
+
+def _validate_weapon_dict(w: dict) -> list[str]:
+    errs: list[str] = []
+    name = w.get("name", "<unnamed>")
+    for p in w.get("properties", []):
+        key, val = (p.split(":", 1) + [None])[:2]
+        if key not in _ALLOWED_PROP_KEYS:
+            errs.append(f"{name}: unknown property '{key}'")
+            continue
+        if key == "range" and not (val and _range_ok(val)):
+            errs.append(f"{name}: bad range '{p}', expected range:X/Y")
+        if key == "versatile" and not (val and _VERSATILE_VAL_PAT.match(val)):
+            errs.append(f"{name}: bad versatile '{p}', expected versatile:XdY")
+        if key == "ammo" and val not in _ALLOWED_AMMO_TYPES:
+            errs.append(
+                f"{name}: bad ammo '{p}', expected one of {sorted(_ALLOWED_AMMO_TYPES)}"
+            )
+    return errs
+
 @dataclass(frozen=True)
 class Weapon:
     name: str
@@ -33,6 +81,24 @@ class Weapon:
         m = re.match(r"(\d+)\/(\d+)", val)
         return (int(m.group(1)), int(m.group(2))) if m else None
 
+    def ammo_type(self) -> Optional[str]:
+        """Return the ammunition type for this weapon, if any."""
+        if not self.has_prop("ammunition"):
+            return None
+        explicit = self.get_prop_value("ammo")
+        if explicit:
+            return explicit
+        n = self.name.lower()
+        if "bow" in n and "cross" not in n:
+            return "arrows"
+        if "crossbow" in n:
+            return "bolts"
+        if "sling" in n:
+            return "stones"
+        if "blowgun" in n:
+            return "needles"
+        return None
+
 
 class WeaponIndex:
     def __init__(self, weapons: Dict[str, Weapon]):
@@ -42,9 +108,13 @@ class WeaponIndex:
     def load(cls, path: Path) -> "WeaponIndex":
         raw = json.loads(path.read_text(encoding="utf-8"))
         weapons = {}
+        errors: list[str] = []
         for w in raw:
+            errors.extend(_validate_weapon_dict(w))
             weapon = Weapon(**w)
             weapons[weapon.name.lower()] = weapon
+        if errors:
+            raise ValueError("; ".join(errors))
         return cls(weapons)
 
     def get(self, name: str) -> Weapon:

--- a/grimbrain/rules/attacks.py
+++ b/grimbrain/rules/attacks.py
@@ -123,12 +123,21 @@ def build_attacks_block(character, weapon_index) -> List[dict]:
             if w.properties
             else ""
         )
+
+        ammo_note = ""
+        at = w.ammo_type()
+        if at:
+            count = character.ammo_count(at)
+            ammo_note = f"{at}: {count}"
+
+        notes = ", ".join(x for x in [props, ammo_note] if x)
+
         out.append(
             {
                 "name": w.name,
                 "attack_bonus": ab,
                 "damage": dmg,
-                "properties": props,
+                "properties": notes,
             }
         )
 
@@ -146,12 +155,20 @@ def build_attacks_block(character, weapon_index) -> List[dict]:
                 if w.properties
                 else ""
             )
+
+            ammo_note = ""
+            at = w.ammo_type()
+            if at:
+                count = character.ammo_count(at)
+                ammo_note = f"{at}: {count}"
+            notes = ", ".join(x for x in [props, ammo_note] if x)
+
             out.append(
                 {
                     "name": f"{w.name} (off-hand)",
                     "attack_bonus": ab,
                     "damage": dmg,
-                    "properties": props,
+                    "properties": notes,
                 }
             )
     return out

--- a/tests/test_ammo.py
+++ b/tests/test_ammo.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from grimbrain.codex.weapons import WeaponIndex
+from grimbrain.character import Character
+
+
+def idx():
+    return WeaponIndex.load(Path("data/weapons.json"))
+
+
+def test_ammo_inference_and_display():
+    i = idx()
+    c = Character(dex_score=16, proficiencies={"simple weapons", "martial weapons"})
+    c.equipped_weapons = ["Shortbow", "Hand Crossbow", "Blowgun"]
+    c.ammo = {"arrows": 20, "bolts": 12, "needles": 5}
+
+    block = c.attacks_and_spellcasting(i)
+    props = {e["name"]: e["properties"] for e in block}
+    assert "arrows: 20" in props["Shortbow"]
+    assert "bolts: 12" in props["Hand Crossbow"]
+    assert "needles: 5" in props["Blowgun"]
+
+
+def test_spend_ammo_success_and_failure():
+    c = Character()
+    c.add_ammo("arrows", 2)
+    assert c.ammo_count("arrows") == 2
+    assert c.spend_ammo("arrows", 1) is True
+    assert c.ammo_count("arrows") == 1
+    assert c.spend_ammo("arrows", 2) is False  # not enough
+    assert c.ammo_count("arrows") == 1
+
+
+def test_explicit_ammo_override():
+    i = idx()
+    w = i.get("Longbow")
+    assert w.ammo_type() == "arrows"


### PR DESCRIPTION
## Summary
- track ammo by type on characters
- infer weapon ammo types and validate ammo property
- show remaining ammo in attack listings

## Testing
- `pytest tests/test_ammo.py -v` *(fails: Required test coverage of 70% not reached, Total coverage: 6.31%)*
- `pytest -q` *(did not complete: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bca260a48327b609364e374488b7