### PR TITLE
Add versatile two-handed damage display

### DIFF
--- a/data/weapons.json
+++ b/data/weapons.json
@@ -78,5 +78,13 @@
     "damage": "1d6",
     "damage_type": "bludgeoning",
     "properties": []
+  },
+  {
+    "name": "Quarterstaff",
+    "category": "simple",
+    "kind": "melee",
+    "damage": "1d6",
+    "damage_type": "bludgeoning",
+    "properties": ["versatile:1d8"]
   }
 ]

--- a/grimbrain/rules/attacks.py
+++ b/grimbrain/rules/attacks.py
@@ -105,6 +105,17 @@ def damage_string(
     return f"{die}{(' ' + mod_str) if mod_str else ''} {weapon.damage_type}"
 
 
+def damage_display(character, weapon: Weapon) -> str:
+    base = damage_string(character, weapon, two_handed=False)
+    v = weapon.versatile_die()
+    if not v:
+        return base
+    two_h = damage_string(character, weapon, two_handed=True)
+    if two_h != base:
+        return f"{base} ({two_h} two-handed)"
+    return base
+
+
 def can_two_weapon(weapon: Weapon) -> bool:
     return weapon.kind == "melee" and ("light" in weapon.properties)
 
@@ -117,7 +128,7 @@ def build_attacks_block(character, weapon_index) -> List[dict]:
         except KeyError:
             continue
         ab = attack_bonus(character, w)
-        dmg = damage_string(character, w, two_handed=False)
+        dmg = damage_display(character, w)
         props = (
             ", ".join(p.replace("range:", "").replace("/", "/") for p in w.properties)
             if w.properties

--- a/tests/golden/attacks_block.golden
+++ b/tests/golden/attacks_block.golden
@@ -1,2 +1,2 @@
-- Longsword: +5 to hit, 1d8 +3 slashing (versatile:1d10)
+- Longsword: +5 to hit, 1d8 +3 slashing (1d10 +3 slashing two-handed) (versatile:1d10)
 - Dagger: +5 to hit, 1d4 +3 piercing (finesse, light, thrown, 20/60)

--- a/tests/test_versatile_display.py
+++ b/tests/test_versatile_display.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from grimbrain.codex.weapons import WeaponIndex
+from grimbrain.rules.attacks import damage_display
+
+
+class C:
+    def __init__(self, str_=16, dex=12, pb=2):
+        self.str_score = str_
+        self.dex_score = dex
+        self.proficiency_bonus = pb
+        self.proficiencies = {"martial weapons", "simple weapons"}
+
+    def ability_mod(self, k):
+        return ({"STR": self.str_score, "DEX": self.dex_score}[k] - 10) // 2
+
+
+def idx():
+    return WeaponIndex.load(Path("data/weapons.json"))
+
+
+def test_longsword_shows_both_modes():
+    i = idx()
+    c = C()
+    w = i.get("longsword")
+    disp = damage_display(c, w)
+    assert "1d8 +3 slashing" in disp
+    assert "(1d10 +3 slashing two-handed)" in disp
+
+
+def test_quarterstaff_shows_both_modes():
+    i = idx()
+    c = C()
+    w = i.get("quarterstaff")
+    disp = damage_display(c, w)
+    assert "1d6 +3 bludgeoning" in disp
+    assert "(1d8 +3 bludgeoning two-handed)" in disp
+
+
+def test_non_versatile_unchanged():
+    i = idx()
+    c = C()
+    w = i.get("rapier")
+    disp = damage_display(c, w)
+    assert "(" not in disp  # no two-handed tail


### PR DESCRIPTION
## Summary
- show versatile weapons' one- and two-handed damage with new `damage_display`
- list quarterstaff in weapons data and update attack block golden
- test that damage display handles versatile and non-versatile weapons

## Testing
- `pytest -o addopts="" tests/test_versatile_display.py -v`
- `pytest -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68b1df2176f48327a484444736e25b6a