### PR TITLE
Add attack math utilities and crit damage helpers

### DIFF
--- a/grimbrain/rules/attack_math.py
+++ b/grimbrain/rules/attack_math.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+from typing import Literal, Tuple
+import re
+
+Die = Tuple[int, int]  # (count, faces)
+_MODE = Literal["none", "advantage", "disadvantage"]
+
+_DIE_PAT = re.compile(r"^(\d+)d(\d+)$")
+
+def parse_die(die: str) -> Die | None:
+    m = _DIE_PAT.match(die)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)))
+
+def double_die_text(die: str) -> str:
+    parsed = parse_die(die)
+    if not parsed:
+        return die  # numbers like "1" or "—" stay as-is for crit
+    n, f = parsed
+    return f"{n*2}d{f}"
+
+def roll_outcome(d: int, attack_bonus: int, ac: int) -> Tuple[bool, bool]:
+    """
+    Single d20 outcome -> (is_hit, is_crit) using 5e rules:
+      - nat 1 always misses
+      - nat 20 always hits & crits
+      - otherwise hit if d + attack_bonus >= ac
+    """
+    if d == 1:
+        return (False, False)
+    if d == 20:
+        return (True, True)
+    return (d + attack_bonus >= ac, False)
+
+def _pair_iter(mode: _MODE):
+    if mode == "none":
+        for d in range(1, 21):
+            yield (d,)
+    else:
+        for d1 in range(1, 21):
+            for d2 in range(1, 21):
+                yield (d1, d2)
+
+def _reduce_to_result(ds: tuple[int, ...], mode: _MODE) -> int:
+    if mode == "none":
+        return ds[0]
+    return max(ds) if mode == "advantage" else min(ds)
+
+def hit_probabilities(attack_bonus: int, ac: int, mode: _MODE = "none"):
+    """
+    Exact probabilities under d20 core rules with nat1/nat20 handling.
+    Returns dict with floats in [0,1]: {'hit': p_any_hit, 'crit': p_crit, 'normal': p_noncrit_hit}
+    """
+    total = 20 if mode == "none" else 400
+    hits = crits = 0
+    for ds in _pair_iter(mode):
+        d = _reduce_to_result(ds, mode)
+        is_hit, is_crit = roll_outcome(d, attack_bonus, ac)
+        hits += 1 if is_hit else 0
+        crits += 1 if is_crit else 0
+    p_hit = hits / total
+    p_crit = crits / total
+    return {"hit": p_hit, "crit": p_crit, "normal": p_hit - p_crit}

--- a/grimbrain/rules/attacks.py
+++ b/grimbrain/rules/attacks.py
@@ -1,5 +1,6 @@
 from typing import List
 from ..codex.weapons import Weapon
+from .attack_math import double_die_text
 
 # Expect character to expose:
 #   ability_mod("STR"/"DEX"), prof or proficiency_bonus, weapon_proficiencies or proficiencies
@@ -103,6 +104,22 @@ def damage_string(
     )
     mod_str = format_mod(mod) if mod != 0 else ""
     return f"{die}{(' ' + mod_str) if mod_str else ''} {weapon.damage_type}"
+
+
+# NEW: crit damage string (doubles dice only)
+def crit_damage_string(
+    character, weapon, *, two_handed: bool = False, offhand: bool = False
+) -> str:
+    die = damage_die(character, weapon, two_handed=two_handed)
+    # If weapon has no dice (e.g., "1" Blowgun) or is "—" Net, leave die as-is / unchanged.
+    if die in {"—", "-"}:
+        return "— special"
+    die_crit = double_die_text(die)
+    mod = damage_modifier(
+        character, weapon, two_handed=two_handed, offhand=offhand
+    )
+    mod_str = format_mod(mod) if mod != 0 else ""
+    return f"{die_crit}{(' ' + mod_str) if mod_str else ''} {weapon.damage_type}"
 
 
 def damage_display(character, weapon: Weapon) -> str:

--- a/scripts/hit_preview.py
+++ b/scripts/hit_preview.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+from grimbrain.codex.weapons import WeaponIndex
+from grimbrain.rules.attacks import damage_string, crit_damage_string, attack_bonus
+from grimbrain.rules.attack_math import hit_probabilities
+
+def pct(x):
+    return f"{x*100:.1f}%"
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ac", type=int, required=True)
+    ap.add_argument("--weapon", required=True)
+    ap.add_argument("--str", dest="str_", type=int, default=16)
+    ap.add_argument("--dex", type=int, default=14)
+    ap.add_argument("--pb", type=int, default=2)
+    ap.add_argument("--twohanded", action="store_true")
+    args = ap.parse_args()
+
+    class C:
+        def __init__(self, s, d, pb):
+            self.str_score = s
+            self.dex_score = d
+            self.proficiency_bonus = pb
+            self.proficiencies = {"simple weapons", "martial weapons"}
+
+        def ability_mod(self, k):
+            return ({"STR": self.str_score, "DEX": self.dex_score}[k] - 10) // 2
+
+    c = C(args.str_, args.dex, args.pb)
+    idx = WeaponIndex.load(Path("data/weapons.json"))
+    w = idx.get(args.weapon)
+
+    ab = attack_bonus(c, w)
+    norm = damage_string(c, w, two_handed=args.twohanded)
+    crit = crit_damage_string(c, w, two_handed=args.twohanded)
+
+    for mode in ("none", "advantage", "disadvantage"):
+        p = hit_probabilities(ab, args.ac, mode)
+        print(
+            f"{w.name} vs AC {args.ac} [{mode}]: hit {pct(p['hit'])} (crit {pct(p['crit'])})  | dmg {norm} / crit {crit}"
+        )
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_attack_math.py
+++ b/tests/test_attack_math.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from grimbrain.codex.weapons import WeaponIndex, Weapon
+from grimbrain.rules.attacks import damage_string, crit_damage_string
+from grimbrain.rules.attack_math import hit_probabilities
+
+
+class C:
+    def __init__(self, str_=16, dex=18, pb=2, styles=None):
+        self.str_score = str_
+        self.dex_score = dex
+        self.proficiency_bonus = pb
+        self.fighting_styles = styles or set()
+        self.proficiencies = {"simple weapons", "martial weapons"}
+
+    def ability_mod(self, k):
+        return ({"STR": self.str_score, "DEX": self.dex_score}[k] - 10) // 2
+
+
+def idx():
+    return WeaponIndex.load(Path("data/weapons.json"))
+
+
+def test_crit_damage_doubles_only_dice():
+    i = idx()
+    c = C()
+    # Greatsword 2d6 -> 4d6 +3
+    w = i.get("greatsword")
+    assert damage_string(c, w) == "2d6 +3 slashing"
+    assert crit_damage_string(c, w) == "4d6 +3 slashing"
+    # Rapier 1d8 -> 2d8 +4 (DEX)
+    r = i.get("rapier")
+    assert "1d8 +4 piercing" == damage_string(c, r)
+    assert "2d8 +4 piercing" == crit_damage_string(c, r)
+    # Blowgun "1" stays "1"
+    b = i.get("blowgun")
+    assert "1 +4 piercing" == damage_string(c, b)
+    assert "1 +4 piercing" == crit_damage_string(c, b)
+    # Net "—"
+    n = Weapon(
+        name="net",
+        category="martial",
+        kind="ranged",
+        damage="—",
+        damage_type="special",
+        properties=[],
+    )
+    assert "— special" == crit_damage_string(c, n)
+
+
+def test_offhand_crit_suppresses_mod_without_style():
+    i = idx()
+    c = C(styles=set())  # no Two-Weapon Fighting
+    d = i.get("dagger")
+    # Off-hand has no ability mod; crit doubles dice only
+    assert crit_damage_string(c, d, offhand=True) == "2d4 piercing"
+
+
+def test_hit_probabilities_basic_and_extremes():
+    # +5 vs AC 15 -> need 10; single: 50% noncrit + 5% crit = 55%
+    p = hit_probabilities(attack_bonus=5, ac=15, mode="none")
+    assert abs(p["hit"] - 0.55) < 1e-9
+    assert abs(p["crit"] - 0.05) < 1e-9
+    # Very high AC (only nat20s land): none=5%, adv≈9.75%, dis=0.25%
+    p_hi = hit_probabilities(attack_bonus=0, ac=30, mode="none")
+    p_hi_adv = hit_probabilities(0, 30, "advantage")
+    p_hi_dis = hit_probabilities(0, 30, "disadvantage")
+    assert abs(p_hi["hit"] - 0.05) < 1e-9
+    assert abs(p_hi_adv["hit"] - 0.0975) < 1e-9
+    assert abs(p_hi_dis["hit"] - 0.0025) < 1e-9
+    # Monotonic sanity: adv > none > dis
+    p_mid = [hit_probabilities(5, 16, m)["hit"] for m in ("disadvantage", "none", "advantage")]
+    assert p_mid[0] < p_mid[1] < p_mid[2]


### PR DESCRIPTION
## Summary
- add attack_math module for die parsing and hit/crit probabilities
- extend attacks module with crit_damage_string
- add hit_preview CLI to inspect hit chances

## Testing
- `pytest tests/test_attack_math.py -v --no-cov`
- `PYTHONPATH=. python scripts/hit_preview.py --ac 15 --weapon longsword --str 16 --dex 14 --pb 2`
- `PYTHONPATH=. python scripts/hit_preview.py --ac 20 --weapon greatsword --str 18 --dex 10 --pb 3 --twohanded`


------
https://chatgpt.com/codex/tasks/task_e_68b1ec96f8748327b8925903c57e19db