### PR TITLE
Surface optional hit/crit odds on attack sheet

### DIFF
--- a/grimbrain/character.py
+++ b/grimbrain/character.py
@@ -33,8 +33,16 @@ class Character:
         self.ammo[ammo_type] = have - amount
         return True
 
-    def attacks_and_spellcasting(self, weapon_index) -> List[dict]:
+    def attacks_and_spellcasting(
+        self,
+        weapon_index,
+        *,
+        target_ac: int | None = None,
+        mode: str = "none",
+    ) -> List[dict]:
         from .rules.attacks import build_attacks_block
 
-        return build_attacks_block(self, weapon_index)
+        return build_attacks_block(
+            self, weapon_index, target_ac=target_ac, mode=mode
+        )
 

--- a/grimbrain/models/pc.py
+++ b/grimbrain/models/pc.py
@@ -144,10 +144,18 @@ class PlayerCharacter(BaseModel):
         return 10 + self.skill_mod("perception")
 
     # --- Attacks ---
-    def attacks(self, weapon_index) -> List[dict]:
+    def attacks(
+        self,
+        weapon_index,
+        *,
+        target_ac: int | None = None,
+        mode: str = "none",
+    ) -> List[dict]:
         from grimbrain.rules.attacks import build_attacks_block
 
-        return build_attacks_block(self, weapon_index)
+        return build_attacks_block(
+            self, weapon_index, target_ac=target_ac, mode=mode
+        )
 
     def attack_bonus(self, ability: str, proficient: bool) -> int:
         return self.ability_mod(ability) + (self.prof if proficient else 0)

--- a/tests/test_sheet_odds.py
+++ b/tests/test_sheet_odds.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from grimbrain.codex.weapons import WeaponIndex
+from grimbrain.rules.attacks import build_attacks_block
+
+
+class C:
+    def __init__(self):
+        self.str_score = 16
+        self.dex_score = 14
+        self.proficiency_bonus = 2
+        self.proficiencies = {"simple weapons", "martial weapons"}
+        self.equipped_weapons = ["Longsword"]
+
+    def ability_mod(self, k):
+        return ({"STR": self.str_score, "DEX": self.dex_score}[k] - 10) // 2
+
+
+def test_odds_string_present_and_sane():
+    i = WeaponIndex.load(Path("data/weapons.json"))
+    c = C()
+    block = build_attacks_block(c, i, target_ac=15, mode="none")
+    odds = block[0]["odds"]
+    assert "hit 55.0%" in odds and "crit 5.0%" in odds and "vs AC 15" in odds
+


### PR DESCRIPTION
## Summary
- show hit/crit odds in `build_attacks_block` when target AC provided
- surface odds on sheet renderers and CLI smoke script
- add regression test for odds formatting

## Testing
- `pytest tests/test_sheet_odds.py -v --no-cov`
- `pytest tests/test_attacks_block.py tests/test_sheet_markdown.py -v --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b1f34939908327a57a1b63a051e461