### PR TITLE
Add weapon notes for special and loading weapons

### DIFF
--- a/data/weapons.json
+++ b/data/weapons.json
@@ -86,5 +86,29 @@
     "damage": "1d6",
     "damage_type": "bludgeoning",
     "properties": ["versatile:1d8"]
+  },
+  {
+    "name": "Light Crossbow",
+    "category": "simple",
+    "kind": "ranged",
+    "damage": "1d8",
+    "damage_type": "piercing",
+    "properties": ["ammunition", "loading", "two-handed", "range:80/320"]
+  },
+  {
+    "name": "Lance",
+    "category": "martial",
+    "kind": "melee",
+    "damage": "1d12",
+    "damage_type": "piercing",
+    "properties": ["reach", "special"]
+  },
+  {
+    "name": "Net",
+    "category": "martial",
+    "kind": "ranged",
+    "damage": "—",
+    "damage_type": "—",
+    "properties": ["special", "thrown", "range:5/15"]
   }
 ]

--- a/grimbrain/rules/attacks.py
+++ b/grimbrain/rules/attacks.py
@@ -1,6 +1,7 @@
 from typing import List
 from ..codex.weapons import Weapon
 from .attack_math import double_die_text, hit_probabilities
+from .weapon_notes import weapon_notes
 
 # Expect character to expose:
 #   ability_mod("STR"/"DEX"), prof or proficiency_bonus, weapon_proficiencies or proficiencies
@@ -168,7 +169,7 @@ def build_attacks_block(
             count = character.ammo_count(at)
             ammo_note = f"{at}: {count}"
 
-        notes = ", ".join(x for x in [props, ammo_note] if x)
+        properties = ", ".join(x for x in [props, ammo_note] if x)
 
         odds = ""
         if target_ac is not None:
@@ -177,13 +178,16 @@ def build_attacks_block(
                 f"hit {_fmt_pct(p['hit'])} • crit {_fmt_pct(p['crit'])} vs AC {target_ac}"
             )
 
+        notes = weapon_notes(w)
+
         out.append(
             {
                 "name": w.name,
                 "attack_bonus": ab,
                 "damage": dmg,
-                "properties": notes,
+                "properties": properties,
                 **({"odds": odds} if odds else {}),
+                **({"notes": notes} if notes else {}),
             }
         )
 
@@ -207,7 +211,7 @@ def build_attacks_block(
             if at:
                 count = character.ammo_count(at)
                 ammo_note = f"{at}: {count}"
-            notes = ", ".join(x for x in [props, ammo_note] if x)
+            properties = ", ".join(x for x in [props, ammo_note] if x)
 
             odds = ""
             if target_ac is not None:
@@ -221,7 +225,7 @@ def build_attacks_block(
                     "name": f"{w.name} (off-hand)",
                     "attack_bonus": ab,
                     "damage": dmg,
-                    "properties": notes,
+                    "properties": properties,
                     **({"odds": odds} if odds else {}),
                 }
             )

--- a/grimbrain/rules/weapon_notes.py
+++ b/grimbrain/rules/weapon_notes.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from typing import List
+from ..codex.weapons import Weapon
+
+def weapon_notes(weapon: Weapon) -> List[str]:
+    notes: List[str] = []
+
+    # Loading (generic)
+    if weapon.has_prop("loading"):
+        notes.append("Loading: only one shot per action/bonus/reaction.")
+
+    # Weapon-specific "special" notes
+    if weapon.has_prop("special"):
+        n = weapon.name.lower()
+        if n == "lance":
+            notes.append("Lance: disadvantage if target is within 5 ft; two-handed when not mounted.")
+        if n == "net":
+            notes.append(
+                "Net: on hit, Large or smaller is restrained until freed; action to escape (STR DC 10) "
+                "or deal 5 slashing to the net (AC 10) to free (net destroyed). No effect on Huge+ or formless."
+            )
+
+    return notes

--- a/grimbrain/sheet.py
+++ b/grimbrain/sheet.py
@@ -116,6 +116,9 @@ def attacks_block(
         if a.get("odds"):
             dmg += f" [{a['odds']}]"
         t.add_row(a["name"], atk, dmg, a["properties"])
+        if a.get("notes"):
+            for n in a["notes"]:
+                t.add_row(f"  · {n}", "", "", "")
     return t
 
 
@@ -229,6 +232,9 @@ def to_markdown(
             out += (
                 f"- {a['name']}: {format_mod(a['attack_bonus'])} to hit, {a['damage']}{odds}{props}\n"
             )
+            if a.get("notes"):
+                for n in a["notes"]:
+                    out += f"  · {n}\n"
         out += "\n"
     out += "## Spellcasting\n\n"
     dc = spell_save_dc(pc)

--- a/scripts/smoke_attacks.py
+++ b/scripts/smoke_attacks.py
@@ -59,6 +59,9 @@ def main():
         if props:
             line += f"  ({props})"
         print(line)
+        if e.get("notes"):
+            for n in e["notes"]:
+                print(f"  · {n}")
 
 
 if __name__ == "__main__":

--- a/tests/test_weapon_notes.py
+++ b/tests/test_weapon_notes.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from grimbrain.codex.weapons import WeaponIndex
+from grimbrain.rules.weapon_notes import weapon_notes
+
+def idx():
+    return WeaponIndex.load(Path("data/weapons.json"))
+
+def test_lance_notes_present():
+    i = idx()
+    w = i.get("lance")
+    notes = " ".join(weapon_notes(w)).lower()
+    assert "disadvantage" in notes and "5 ft" in notes and "two-handed" in notes
+
+def test_net_notes_present():
+    i = idx()
+    w = i.get("net")
+    notes = " ".join(weapon_notes(w)).lower()
+    assert "restrained" in notes and "str dc 10" in notes and "ac 10" in notes
+
+def test_loading_note_on_crossbow():
+    i = idx()
+    w = i.get("light crossbow")
+    notes = " ".join(weapon_notes(w)).lower()
+    assert "loading" in notes and "one shot" in notes


### PR DESCRIPTION
## Summary
- add weapon_notes helper to supply loading/lance/net notes
- show weapon notes in attacks blocks, console, and smoke script
- expand weapon data and tests for lance, net, light crossbow

## Testing
- `PYTEST_ADDOPTS="--cov=grimbrain.rules.weapon_notes --cov-fail-under=0" pytest tests/test_weapon_notes.py -v`
- `PYTEST_ADDOPTS="--cov-fail-under=0" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ece6d40c8327b1826fe259662e69