### PR TITLE
feat: add range and cover context to attacks

### DIFF
--- a/grimbrain/rules/attack_math.py
+++ b/grimbrain/rules/attack_math.py
@@ -5,6 +5,21 @@ import re
 Die = Tuple[int, int]  # (count, faces)
 _MODE = Literal["none", "advantage", "disadvantage"]
 
+def combine_modes(a: _MODE, b: _MODE) -> _MODE:
+    """Combine two advantage states.
+
+    Any combination of advantage and disadvantage cancels to "none". If one side
+    is "none", the other side wins. Otherwise the inputs match and are returned
+    unchanged.
+    """
+    if a == b:
+        return a
+    if a == "none":
+        return b
+    if b == "none":
+        return a
+    return "none"
+
 _DIE_PAT = re.compile(r"^(\d+)d(\d+)$")
 
 def parse_die(die: str) -> Die | None:

--- a/scripts/hit_preview.py
+++ b/scripts/hit_preview.py
@@ -2,11 +2,11 @@
 import argparse
 from pathlib import Path
 from grimbrain.codex.weapons import WeaponIndex
-from grimbrain.rules.attacks import damage_string, crit_damage_string, attack_bonus
-from grimbrain.rules.attack_math import hit_probabilities
-
-def pct(x):
-    return f"{x*100:.1f}%"
+from grimbrain.rules.attacks import (
+    damage_string,
+    crit_damage_string,
+    build_attacks_block,
+)
 
 def main():
     ap = argparse.ArgumentParser()
@@ -16,6 +16,12 @@ def main():
     ap.add_argument("--dex", type=int, default=14)
     ap.add_argument("--pb", type=int, default=2)
     ap.add_argument("--twohanded", action="store_true")
+    ap.add_argument("--distance", type=int, default=None, help="Target distance in feet")
+    ap.add_argument(
+        "--cover",
+        choices=["none", "half", "three-quarters", "total"],
+        default="none",
+    )
     args = ap.parse_args()
 
     class C:
@@ -28,18 +34,29 @@ def main():
         def ability_mod(self, k):
             return ({"STR": self.str_score, "DEX": self.dex_score}[k] - 10) // 2
 
+        def ammo_count(self, _):
+            return 0
+
     c = C(args.str_, args.dex, args.pb)
     idx = WeaponIndex.load(Path("data/weapons.json"))
     w = idx.get(args.weapon)
+    c.equipped_weapons = [w.name]
 
-    ab = attack_bonus(c, w)
     norm = damage_string(c, w, two_handed=args.twohanded)
     crit = crit_damage_string(c, w, two_handed=args.twohanded)
 
     for mode in ("none", "advantage", "disadvantage"):
-        p = hit_probabilities(ab, args.ac, mode)
+        block = build_attacks_block(
+            c,
+            idx,
+            target_ac=args.ac,
+            mode=mode,
+            target_distance=args.distance,
+            cover=args.cover,
+        )
+        odds = block[0]["odds"] if block else ""
         print(
-            f"{w.name} vs AC {args.ac} [{mode}]: hit {pct(p['hit'])} (crit {pct(p['crit'])})  | dmg {norm} / crit {crit}"
+            f"{w.name} vs AC {args.ac} [{mode}]: {odds}  | dmg {norm} / crit {crit}"
         )
 
 if __name__ == "__main__":

--- a/tests/test_range_cover.py
+++ b/tests/test_range_cover.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+from grimbrain.codex.weapons import WeaponIndex
+from grimbrain.rules.attacks import build_attacks_block
+
+
+class C:
+    def __init__(self, str_=16, dex=18, pb=2, feats=None):
+        self.str_score = str_
+        self.dex_score = dex
+        self.proficiency_bonus = pb
+        self.proficiencies = {"simple weapons", "martial weapons"}
+        self.fighting_styles = set()
+        self.feats = set(feats or [])
+        self.equipped_weapons = ["Longbow", "Dagger"]
+        self.equipped_offhand = None
+
+    def ability_mod(self, k):
+        return ({"STR": self.str_score, "DEX": self.dex_score}[k] - 10) // 2
+
+    def ammo_count(self, _):
+        return 0
+
+
+def idx():
+    return WeaponIndex.load(Path("data/weapons.json"))
+
+
+def _odds_of(name, block):
+    return next(e["odds"] for e in block if e["name"].lower() == name.lower())
+
+
+def test_long_range_imposes_disadvantage_without_ss():
+    i = idx()
+    c = C(feats=set())
+    b1 = build_attacks_block(
+        c, i, target_ac=15, target_distance=200, cover="none", mode="none"
+    )
+    b0 = build_attacks_block(
+        c, i, target_ac=15, target_distance=100, cover="none", mode="none"
+    )
+    o1 = _odds_of("Longbow", b1)
+    o0 = _odds_of("Longbow", b0)
+    assert "long range" in o1.lower()
+    hit1 = float(o1.split("hit ")[1].split("%")[0])
+    hit0 = float(o0.split("hit ")[1].split("%")[0])
+    assert hit1 < hit0
+
+
+def test_sharpshooter_cancels_long_range_disadvantage():
+    i = idx()
+    c = C(feats={"Sharpshooter"})
+    b = build_attacks_block(
+        c, i, target_ac=15, target_distance=200, cover="none", mode="none"
+    )
+    o = _odds_of("Longbow", b)
+    assert "no disadvantage" in o.lower()
+
+
+def test_cover_adds_to_ac_unless_ss_ignores():
+    i = idx()
+    c = C()
+    b_cov = build_attacks_block(c, i, target_ac=15, cover="half", mode="none")
+    b_none = build_attacks_block(c, i, target_ac=15, cover="none", mode="none")
+    oc = _odds_of("Longbow", b_cov)
+    on = _odds_of("Longbow", b_none)
+    hc = float(oc.split("vs AC ")[1].split()[0])
+    hn = float(on.split("vs AC ")[1].split()[0])
+    assert hc == hn + 2
+
+    c_ss = C(feats={"Sharpshooter"})
+    b_ss = build_attacks_block(c_ss, i, target_ac=15, cover="three-quarters")
+    o_ss = _odds_of("Longbow", b_ss)
+    assert "ignore cover" in o_ss.lower()
+    ac_ss = float(o_ss.split("vs AC ")[1].split()[0])
+    assert ac_ss == 15
+
+
+def test_out_of_range_and_total_cover_unattackable():
+    i = idx()
+    c = C()
+    b1 = build_attacks_block(c, i, target_ac=15, target_distance=1000, cover="none")
+    assert "unattackable" in _odds_of("Longbow", b1).lower()
+    b2 = build_attacks_block(c, i, target_ac=15, cover="total")
+    assert "unattackable" in _odds_of("Longbow", b2).lower()
+
+
+def test_thrown_weapons_use_range_profile():
+    i = idx()
+    c = C()
+    b = build_attacks_block(c, i, target_ac=15, target_distance=50, cover="none")
+    o = _odds_of("Dagger", b)
+    assert "long range" in o.lower()
+


### PR DESCRIPTION
## Summary
- support combining advantage/disadvantage modes
- factor range and cover into attack odds and CLI hit preview
- add tests for range and cover interactions and Sharpshooter

## Testing
- `pytest tests/test_range_cover.py -v --no-cov`
- `pytest -q --no-cov`
- `PYTHONPATH=. python scripts/hit_preview.py --ac 15 --weapon Longbow --dex 18 --pb 2 --distance 200 --cover half`


------
https://chatgpt.com/codex/tasks/task_e_68b749c83cb4832789a0cc52d71ee769