### PR TITLE
feat: resolve attacks with damage and ammo

### DIFF
--- a/grimbrain/engine/types.py
+++ b/grimbrain/engine/types.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import Optional, Literal
+
+Cover = Literal["none", "half", "three-quarters", "total"]
+
+
+@dataclass
+class Target:
+    ac: int
+    hp: int
+    cover: Cover = "none"
+    distance_ft: Optional[int] = None

--- a/scripts/attack.py
+++ b/scripts/attack.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import argparse, random
+from pathlib import Path
+from grimbrain.codex.weapons import WeaponIndex
+from grimbrain.character import Character
+from grimbrain.engine.types import Target
+from grimbrain.engine.combat import resolve_attack
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Grimbrain single attack demo")
+    ap.add_argument("--weapon", required=True)
+    ap.add_argument("--ac", type=int, required=True)
+    ap.add_argument("--hp", type=int, default=10)
+    ap.add_argument("--distance", type=int, default=None)
+    ap.add_argument("--cover", choices=["none","half","three-quarters","total"], default="none")
+    ap.add_argument("--mode", choices=["none","advantage","disadvantage"], default="none")
+    ap.add_argument("--power", action="store_true", help="-5/+10 if eligible (SS/GWM)")
+    ap.add_argument("--offhand", action="store_true")
+    ap.add_argument("--twohanded", action="store_true")
+    ap.add_argument("--dex", type=int, default=16)
+    ap.add_argument("--str", type=int, default=16)
+    ap.add_argument("--pb", type=int, default=2)
+    ap.add_argument("--styles", nargs="*", default=[], help='e.g. Archery Dueling "Two-Weapon Fighting"')
+    ap.add_argument("--feats", nargs="*", default=[], help="e.g. Sharpshooter 'Great Weapon Master'")
+    ap.add_argument("--ammo", nargs="*", default=[], help="pairs like arrows:20 bolts:10")
+    args = ap.parse_args()
+
+    # quick character stub
+    c = Character(str_score=args.str, dex_score=args.dex, proficiency_bonus=args.pb,
+                  proficiencies={"simple weapons","martial weapons"},
+                  fighting_styles=set(args.styles), equipped_weapons=[args.weapon],
+                  ammo={k:int(v) for k,v in (x.split(":",1) for x in args.ammo)})
+
+    idx = WeaponIndex.load(Path("data/weapons.json"))
+    tgt = Target(ac=args.ac, hp=args.hp, cover=args.cover, distance_ft=args.distance)
+
+    res = resolve_attack(c, args.weapon, tgt, idx,
+                         base_mode=args.mode, power=args.power,
+                         offhand=args.offhand, two_handed=args.twohanded,
+                         has_fired_loading_weapon_this_turn=False, rng=random.Random())
+
+    if not res.get("ok"):
+        print(f"Attack not possible: {res.get('reason')} [{', '.join(res.get('notes', []))}]")
+        return
+
+    print(f"{res['weapon']} vs AC {res['effective_ac']} [{args.mode}]  notes: {', '.join(res['notes']) if res['notes'] else '-'}")
+    cands = "/".join(map(str, res['candidates']))
+    print(f"  d20: {res['d20']} (candidates {cands})  AB {res['attack_bonus']}  =>  {'CRIT' if res['is_crit'] else ('HIT' if res['is_hit'] else 'MISS')}")
+    print(f"  damage ({res['damage_string']}): rolls={res['damage']['rolls']} sum={res['damage']['sum_dice']} mod={res['damage']['mod']}  TOTAL={res['damage']['total']}")
+    if res['spent_ammo']:
+        print("  ammo: spent 1")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from grimbrain.codex.weapons import WeaponIndex
+from grimbrain.engine.types import Target
+from grimbrain.engine.combat import resolve_attack
+import random
+
+
+class C:
+    def __init__(self, str_=16, dex=16, pb=2, styles=None, feats=None, ammo=None):
+        self.str_score=str_; self.dex_score=dex; self.proficiency_bonus=pb
+        self.fighting_styles=set(styles or [])
+        self.proficiencies={"simple weapons","martial weapons"}
+        self.feats=set(feats or [])
+        self.ammo=dict(ammo or {})
+    def ability_mod(self,k): return ({"STR":self.str_score,"DEX":self.dex_score}[k]-10)//2
+    def ammo_count(self,t): return int(self.ammo.get(t,0))
+    def spend_ammo(self,t,n=1):
+        if self.ammo.get(t,0) < n: return False
+        self.ammo[t]-=n; return True
+
+def idx(): return WeaponIndex.load(Path("data/weapons.json"))
+
+def test_basic_hit_and_damage_rolls_are_deterministic():
+    i=idx(); c=C(dex=18, feats={"Sharpshooter"}, ammo={"arrows":5})  # SS ensures no long-range disadvantage
+    tgt = Target(ac=15, hp=10, cover="none", distance_ft=30)
+    # Force d20 to 12 (no crit); Longbow AB: +4 DEX +2 PB = +6
+    res = resolve_attack(c, "Longbow", tgt, i, base_mode="none", power=False,
+                         rng=random.Random(1), forced_d20=(12,7))
+    assert res["ok"] and res["is_hit"] and not res["is_crit"]
+    assert res["d20"] == 12 and res["attack_bonus"] == 6
+
+def test_crit_doubles_dice_not_mod():
+    i=idx(); c=C(str_=16)
+    tgt = Target(ac=10, hp=10)
+    # Greatsword: 2d6 +3; force nat 20 => crit
+    res = resolve_attack(c, "Greatsword", tgt, i, base_mode="none", rng=random.Random(2), forced_d20=(20,5))
+    assert res["is_crit"] and res["damage"]["sum_dice"] >= 4  # 4d6 minimum 4
+    assert res["damage"]["mod"] == 3
+
+def test_ammo_spend_and_out_of_ammo():
+    i=idx(); c=C(dex=16, ammo={"arrows":1})
+    tgt = Target(ac=12, hp=10, distance_ft=50)
+    # first shot ok
+    r1 = resolve_attack(c, "Shortbow", tgt, i, rng=random.Random(3), forced_d20=(15,2))
+    assert r1["ok"] and r1["spent_ammo"] and c.ammo["arrows"]==0
+    # second shot blocked
+    r2 = resolve_attack(c, "Shortbow", tgt, i, rng=random.Random(3), forced_d20=(15,2))
+    assert not r2["ok"] and "no arrows" in r2["reason"]
+
+def test_loading_enforced_once_per_turn():
+    i=idx(); c=C(dex=16, ammo={"bolts":10})
+    tgt = Target(ac=12, hp=10, distance_ft=30)
+    # first light crossbow shot allowed
+    r1 = resolve_attack(c, "Light Crossbow", tgt, i, has_fired_loading_weapon_this_turn=False,
+                        rng=random.Random(4), forced_d20=(10,10))
+    assert r1["ok"]
+    # second shot in same turn blocked by loading
+    r2 = resolve_attack(c, "Light Crossbow", tgt, i, has_fired_loading_weapon_this_turn=True,
+                        rng=random.Random(4), forced_d20=(10,10))
+    assert not r2["ok"] and "loading" in r2["reason"]
+
+def test_range_and_cover_effects():
+    i=idx(); c=C(dex=18, ammo={"arrows":5})  # no Sharpshooter, so long range should impose disadvantage
+    tgt_far = Target(ac=15, hp=10, distance_ft=200, cover="half")  # Longbow 150/600
+    res = resolve_attack(c, "Longbow", tgt_far, i, base_mode="advantage", rng=random.Random(5), forced_d20=(8,17))
+    # advantage + disadvantage -> none; half cover bumps AC by +2
+    assert res["effective_ac"] == 17 and res["mode"] == "none"


### PR DESCRIPTION
## Summary
- add `Target` dataclass and cover type
- implement `resolve_attack` engine with ammo, range, cover and crit handling
- provide CLI demo `scripts/attack.py` and deterministic tests

## Testing
- `pytest --no-cov tests/test_combat_engine.py -v`
- `PYTHONPATH=. python scripts/attack.py --weapon Longbow --ac 15 --hp 12 --dex 18 --pb 2 --ammo arrows:20 --distance 200 --cover half --mode none`


------
https://chatgpt.com/codex/tasks/task_e_68b8491ee7b08327bafff5826e7315d8