### PR TITLE
Add scene runner with movement and simple AI

### DIFF
--- a/data/weapons.json
+++ b/data/weapons.json
@@ -48,6 +48,14 @@
     "properties": ["heavy", "two-handed"]
   },
   {
+    "name": "Glaive",
+    "category": "martial",
+    "kind": "melee",
+    "damage": "1d10",
+    "damage_type": "slashing",
+    "properties": ["heavy", "reach", "two-handed"]
+  },
+  {
     "name": "Shortbow",
     "category": "simple",
     "kind": "ranged",

--- a/grimbrain/character.py
+++ b/grimbrain/character.py
@@ -12,6 +12,7 @@ class Character:
     proficiency_bonus: int = 2
     fighting_styles: Set[str] = field(default_factory=set)
     feats: Set[str] = field(default_factory=set)
+    speed_ft: int = 30
     equipped_weapons: List[str] = field(default_factory=list)
     equipped_offhand: Optional[str] = None
     equipped_armor: Optional[str] = None   # e.g., "Chain Mail"

--- a/grimbrain/engine/scene.py
+++ b/grimbrain/engine/scene.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List, Dict, Tuple
+import random
+from pathlib import Path
+
+from .types import Combatant, Target
+from .round import roll_initiative   # reuse your initiative helper
+from ..codex.weapons import WeaponIndex
+from ..codex.armor import ArmorIndex
+from ..rules.defense import compute_ac
+from ..rules.attacks import can_two_weapon
+from .combat import resolve_attack
+
+
+def _reach_ft(weapon) -> int:
+    return 10 if weapon.has_prop("reach") else 5
+
+
+def _speed(cmb: Combatant) -> int:
+    return getattr(cmb.actor, "speed_ft", 30)
+
+
+def _ac_for(defender: Combatant, armor_idx: ArmorIndex) -> int:
+    return int(compute_ac(defender.actor, armor_idx)["ac"])
+
+
+def _move_toward(dist: int, feet: int) -> int:
+    return max(0, dist - max(0, feet))
+
+
+def _move_away(dist: int, feet: int) -> int:
+    return dist + max(0, feet)
+
+
+@dataclass
+class SceneResult:
+    winner: str
+    rounds: int
+    log: List[str]
+    final_distance_ft: int
+    a_hp: int
+    b_hp: int
+
+
+def _take_scene_turn(attacker: Combatant, defender: Combatant, *,
+                     weapon_idx: WeaponIndex, armor_idx: ArmorIndex,
+                     rng: random.Random, distance_ft: int) -> Tuple[List[str], int, bool]:
+    """
+    Returns (log, new_distance_ft, defender_dropped)
+    """
+    log: List[str] = []
+    speed = _speed(attacker)
+    w_main = weapon_idx.get(attacker.weapon)
+    reach = _reach_ft(w_main)
+
+    # Decide movement
+    new_dist = distance_ft
+    performed_action = False
+    used_loading_this_turn = False
+
+    # Simple policies
+    if w_main.kind == "melee":
+        if new_dist > reach:
+            step = min(speed, new_dist - reach)
+            new_dist2 = _move_toward(new_dist, step)
+            log.append(f"{attacker.name} moves: {new_dist}ft -> {new_dist2}ft")
+            new_dist = new_dist2
+        # Attack if in reach
+        if new_dist <= reach:
+            res = resolve_attack(
+                attacker.actor, attacker.weapon,
+                Target(ac=_ac_for(defender, armor_idx), hp=defender.hp, cover=defender.cover, distance_ft=new_dist),
+                weapon_idx, base_mode="none", power=False, offhand=False, two_handed=False,
+                has_fired_loading_weapon_this_turn=False, rng=rng
+            )
+            if not res["ok"]:
+                log.append(f"{attacker.name} cannot attack: {res['reason']}")
+            else:
+                tag = "CRIT" if res["is_crit"] else ("HIT" if res["is_hit"] else "MISS")
+                log.append(f"{attacker.name} attacks with {res['weapon']} @ {new_dist}ft => {tag}")
+                log.append(f"  damage {res['damage_string']}: rolls={res['damage']['rolls']} total={res['damage']['total']}")
+                if res["spent_ammo"]:
+                    log.append("  ammo: spent 1")
+                defender.hp -= int(res["damage"]["total"])
+                performed_action = True
+                if w_main.has_prop("loading"):
+                    used_loading_this_turn = True
+                if defender.hp <= 0:
+                    log.append(f"{defender.name} drops to 0 HP!")
+                    return (log, new_dist, True)
+        # Optional off-hand if applicable and still alive/in reach
+        if defender.hp > 0 and attacker.offhand:
+            w_off = weapon_idx.get(attacker.offhand)
+            if can_two_weapon(w_off) and new_dist <= _reach_ft(w_off):
+                res = resolve_attack(
+                    attacker.actor, attacker.offhand,
+                    Target(ac=_ac_for(defender, armor_idx), hp=defender.hp, cover=defender.cover, distance_ft=new_dist),
+                    weapon_idx, base_mode="none", power=False, offhand=True, two_handed=False,
+                    has_fired_loading_weapon_this_turn=used_loading_this_turn, rng=rng
+                )
+                if res["ok"]:
+                    tag = "CRIT" if res["is_crit"] else ("HIT" if res["is_hit"] else "MISS")
+                    log.append(f"  Off-hand {res['weapon']} => {tag}")
+                    log.append(f"    damage {res['damage_string']}: rolls={res['damage']['rolls']} total={res['damage']['total']}")
+                    defender.hp -= int(res["damage"]["total"])
+                    if defender.hp <= 0:
+                        log.append(f"{defender.name} drops to 0 HP!")
+                        return (log, new_dist, True)
+        return (log, new_dist, False)
+
+    # Ranged logic (kite)
+    KITE = 30  # desired standoff distance
+    if new_dist <= 5:
+        # Disengage and step back, then shoot
+        step = min(speed, KITE - new_dist if KITE > new_dist else speed)
+        new_dist = _move_away(new_dist, step)
+        log.append(f"{attacker.name} disengages and moves: {distance_ft}ft -> {new_dist}ft")
+        res = resolve_attack(
+            attacker.actor,
+            attacker.weapon,
+            Target(
+                ac=_ac_for(defender, armor_idx),
+                hp=defender.hp,
+                cover=defender.cover,
+                distance_ft=new_dist,
+            ),
+            weapon_idx,
+            base_mode="none",
+            power=False,
+            offhand=False,
+            two_handed=False,
+            has_fired_loading_weapon_this_turn=False,
+            rng=rng,
+        )
+        if not res["ok"]:
+            log.append(f"{attacker.name} cannot attack: {res['reason']}")
+            return (log, new_dist, False)
+        tag = "CRIT" if res["is_crit"] else ("HIT" if res["is_hit"] else "MISS")
+        log.append(f"{attacker.name} shoots with {res['weapon']} @ {new_dist}ft => {tag}")
+        log.append(
+            f"  damage {res['damage_string']}: rolls={res['damage']['rolls']} total={res['damage']['total']}"
+        )
+        if res["spent_ammo"]:
+            log.append("  ammo: spent 1")
+        defender.hp -= int(res["damage"]["total"])
+        if defender.hp <= 0:
+            log.append(f"{defender.name} drops to 0 HP!")
+            return (log, new_dist, True)
+        return (log, new_dist, False)
+    else:
+        # Step back toward kite distance (free move), then shoot
+        if new_dist < KITE:
+            step = min(speed, KITE - new_dist)
+            new_dist2 = _move_away(new_dist, step)
+            log.append(f"{attacker.name} moves: {new_dist}ft -> {new_dist2}ft")
+            new_dist = new_dist2
+        res = resolve_attack(
+            attacker.actor, attacker.weapon,
+            Target(ac=_ac_for(defender, armor_idx), hp=defender.hp, cover=defender.cover, distance_ft=new_dist),
+            weapon_idx, base_mode="none", power=False, offhand=False, two_handed=False,
+            has_fired_loading_weapon_this_turn=False, rng=rng
+        )
+        if not res["ok"]:
+            log.append(f"{attacker.name} cannot attack: {res['reason']}")
+            return (log, new_dist, False)
+        tag = "CRIT" if res["is_crit"] else ("HIT" if res["is_hit"] else "MISS")
+        log.append(f"{attacker.name} shoots with {res['weapon']} @ {new_dist}ft => {tag}")
+        log.append(f"  damage {res['damage_string']}: rolls={res['damage']['rolls']} total={res['damage']['total']}")
+        if res["spent_ammo"]:
+            log.append("  ammo: spent 1")
+        defender.hp -= int(res["damage"]["total"])
+        if defender.hp <= 0:
+            log.append(f"{defender.name} drops to 0 HP!")
+            return (log, new_dist, True)
+        return (log, new_dist, False)
+
+
+def run_scene(a: Combatant, b: Combatant, *, seed: int = 42, max_rounds: int = 20, start_distance_ft: int = 30) -> SceneResult:
+    rng = random.Random(seed)
+    widx = WeaponIndex.load(Path("data/weapons.json"))
+    aidx = ArmorIndex.load(Path("data/armor.json"))
+
+    first, second, init = roll_initiative(a, b, rng)
+    distance = start_distance_ft
+    log: List[str] = [f"Initiative — {first.name} vs {second.name}: {init['A']} to {init['B']}", f"Start distance: {distance}ft"]
+    round_no = 1
+
+    while a.hp > 0 and b.hp > 0 and round_no <= max_rounds:
+        log.append(f"— Round {round_no} —")
+        # First acts
+        tlog, distance, down = _take_scene_turn(first, second, weapon_idx=widx, armor_idx=aidx, rng=rng, distance_ft=distance)
+        log.extend(tlog)
+        if down:
+            break
+        # Second acts
+        tlog, distance, down = _take_scene_turn(second, first, weapon_idx=widx, armor_idx=aidx, rng=rng, distance_ft=distance)
+        log.extend(tlog)
+        if down:
+            break
+        round_no += 1
+
+    winner = first.name if second.hp <= 0 else (second.name if first.hp <= 0 else "none")
+    return SceneResult(winner=winner, rounds=round_no if winner != "none" else max_rounds, log=log,
+                       final_distance_ft=distance, a_hp=a.hp, b_hp=b.hp)
+

--- a/scripts/scene_fight.py
+++ b/scripts/scene_fight.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+import argparse
+from grimbrain.engine.types import Combatant
+from grimbrain.engine.scene import run_scene
+from grimbrain.character import Character
+
+
+def make_char(str_, dex, pb, styles, feats, profs, speed):
+    return Character(
+        str_score=str_,
+        dex_score=dex,
+        proficiency_bonus=pb,
+        fighting_styles=set(styles),
+        feats=set(feats),
+        proficiencies=set(profs),
+        speed_ft=speed,
+        ammo={"arrows": 99, "bolts": 99},
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Grimbrain scene fight (movement + simple AI)")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--rounds", type=int, default=20)
+    ap.add_argument("--start", type=int, default=30, help="starting distance (ft)")
+
+    # A
+    ap.add_argument("--a-name", default="A")
+    ap.add_argument("--a-weapon", required=True)
+    ap.add_argument("--a-offhand", default=None)
+    ap.add_argument("--a-hp", type=int, default=20)
+    ap.add_argument("--a-str", type=int, default=16)
+    ap.add_argument("--a-dex", type=int, default=14)
+    ap.add_argument("--a-pb", type=int, default=2)
+    ap.add_argument("--a-speed", type=int, default=30)
+    ap.add_argument("--a-styles", nargs="*", default=[])
+    ap.add_argument("--a-feats", nargs="*", default=[])
+    ap.add_argument("--a-profs", nargs="*", default=["simple weapons", "martial weapons"])
+    ap.add_argument("--a-cover", choices=["none", "half", "three-quarters", "total"], default="none")
+
+    # B
+    ap.add_argument("--b-name", default="B")
+    ap.add_argument("--b-weapon", required=True)
+    ap.add_argument("--b-offhand", default=None)
+    ap.add_argument("--b-hp", type=int, default=20)
+    ap.add_argument("--b-str", type=int, default=16)
+    ap.add_argument("--b-dex", type=int, default=14)
+    ap.add_argument("--b-pb", type=int, default=2)
+    ap.add_argument("--b-speed", type=int, default=30)
+    ap.add_argument("--b-styles", nargs="*", default=[])
+    ap.add_argument("--b-feats", nargs="*", default=[])
+    ap.add_argument("--b-profs", nargs="*", default=["simple weapons", "martial weapons"])
+    ap.add_argument("--b-cover", choices=["none", "half", "three-quarters", "total"], default="none")
+
+    args = ap.parse_args()
+
+    A = Combatant(
+        name=args.a_name,
+        actor=make_char(
+            args.a_str,
+            args.a_dex,
+            args.a_pb,
+            args.a_styles,
+            args.a_feats,
+            args.a_profs,
+            args.a_speed,
+        ),
+        hp=args.a_hp,
+        weapon=args.a_weapon,
+        offhand=args.a_offhand,
+        distance_ft=None,
+        cover=args.a_cover,
+    )
+    B = Combatant(
+        name=args.b_name,
+        actor=make_char(
+            args.b_str,
+            args.b_dex,
+            args.b_pb,
+            args.b_styles,
+            args.b_feats,
+            args.b_profs,
+            args.b_speed,
+        ),
+        hp=args.b_hp,
+        weapon=args.b_weapon,
+        offhand=args.b_offhand,
+        distance_ft=None,
+        cover=args.b_cover,
+    )
+
+    res = run_scene(A, B, seed=args.seed, max_rounds=args.rounds, start_distance_ft=args.start)
+    print("\n".join(res.log))
+    print(
+        f"\nResult: winner = {res.winner} (A_hp={res.a_hp}  B_hp={res.b_hp}) after {res.rounds} round(s) — final distance {res.final_distance_ft}ft"
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_scene_runner.py
+++ b/tests/test_scene_runner.py
@@ -1,0 +1,43 @@
+from grimbrain.engine.types import Combatant
+from grimbrain.engine.scene import run_scene
+from grimbrain.character import Character
+
+
+def C(str_=16, dex=16, pb=2, styles=None, feats=None, speed=30):
+    return Character(
+        str_score=str_,
+        dex_score=dex,
+        proficiency_bonus=pb,
+        fighting_styles=set(styles or []),
+        feats=set(feats or []),
+        proficiencies={"simple weapons", "martial weapons"},
+        speed_ft=speed,
+        ammo={"arrows": 99},
+    )
+
+
+def test_melee_closes_then_hits():
+    A = Combatant("Melee", C(str_=18), hp=22, weapon="Greatsword")
+    B = Combatant("Archer", C(dex=14, feats={"Sharpshooter"}), hp=16, weapon="Longbow")
+    res = run_scene(A, B, seed=9, max_rounds=5, start_distance_ft=40)
+    log = "\n".join(res.log).lower()
+    assert "moves: 40ft -> 10ft" in log or "moves: 40ft -> 30ft" in log  # first approach step
+    assert "attacks with greatsword" in log  # eventually closes and swings
+
+
+def test_archer_kites_out_of_melee_and_shoots():
+    A = Combatant("Archer", C(dex=18, feats={"Sharpshooter"}), hp=18, weapon="Longbow")
+    B = Combatant("Bandit", C(str_=16), hp=14, weapon="Scimitar")
+    res = run_scene(A, B, seed=11, max_rounds=8, start_distance_ft=20)
+    log = "\n".join(res.log).lower()
+    assert "disengages and moves" in log or "moves: 20ft -> 30ft" in log
+    assert "shoots with longbow" in log
+
+
+def test_reach_10ft_allows_earlier_hits():
+    A = Combatant("GlaiveUser", C(str_=16), hp=20, weapon="Glaive")
+    B = Combatant("Dummy", C(str_=10), hp=12, weapon="Mace")
+    res = run_scene(A, B, seed=5, max_rounds=3, start_distance_ft=15)
+    # Should only need to step 5ft to be in reach and attack on round 1
+    assert "GlaiveUser attacks with Glaive" in "\n".join(res.log)
+


### PR DESCRIPTION
## Summary
- track character speed for movement calculations
- add scene runner with distance handling and basic AI for melee and ranged combatants
- provide CLI and tests for scene fights, plus Glaive weapon data

## Testing
- `PYTEST_ADDOPTS="--cov=grimbrain/engine/scene.py --cov-fail-under=0" pytest tests/test_scene_runner.py -v`
- `PYTEST_ADDOPTS="--cov=grimbrain/engine/scene.py --cov-fail-under=0" pytest -q` *(fails: KeyboardInterrupt)*
- `PYTHONPATH=. python scripts/scene_fight.py --start 40 --a-name Melee --a-weapon Greatsword --a-hp 22 --b-name Archer --b-weapon Longbow --b-hp 16 --b-feats Sharpshooter --seed 9`
- `PYTHONPATH=. python scripts/scene_fight.py --start 20 --a-name Archer --a-weapon Longbow --a-feats Sharpshooter --a-dex 18 --a-hp 18 --b-name Bandit --b-weapon Scimitar --b-hp 14 --seed 11`


------
https://chatgpt.com/codex/tasks/task_e_68b85bd21fc88327bd8f6efc91309b03