### PR TITLE
feat: support multiple attacks per action

### DIFF
--- a/grimbrain/character.py
+++ b/grimbrain/character.py
@@ -13,6 +13,7 @@ class Character:
     fighting_styles: Set[str] = field(default_factory=set)
     feats: Set[str] = field(default_factory=set)
     speed_ft: int = 30
+    attacks_per_action: int = 1
     equipped_weapons: List[str] = field(default_factory=list)
     equipped_offhand: Optional[str] = None
     equipped_armor: Optional[str] = None   # e.g., "Chain Mail"

--- a/grimbrain/engine/round.py
+++ b/grimbrain/engine/round.py
@@ -141,17 +141,34 @@ def take_turn(attacker: Combatant, defender: Combatant, *,
     # Track per-turn loading usage
     used_loading = False
 
-    # Primary attack
-    t1 = _attack_once(attacker, defender, attacker.weapon, weapon_idx=weapon_idx, armor_idx=armor_idx, rng=rng, already_loaded_this_turn=used_loading)
-    log.extend(t1.log)
-    defender.hp -= t1.damage
-    used_loading = used_loading or t1.used_loading
-    if defender.hp <= 0:
-        log.append(f"{defender.name} drops to 0 HP!")
-        return log
+    # Primary attack(s)
+    swings = max(1, int(getattr(attacker.actor, "attacks_per_action", 1)))
+    for i in range(swings):
+        t1 = _attack_once(
+            attacker,
+            defender,
+            attacker.weapon,
+            weapon_idx=weapon_idx,
+            armor_idx=armor_idx,
+            rng=rng,
+            already_loaded_this_turn=used_loading,
+        )
+        log.extend([f"[Attack {i+1}/{swings}]"] + t1.log)
+        defender.hp -= t1.damage
+        used_loading = used_loading or t1.used_loading
+        if defender.hp <= 0:
+            log.append(f"{defender.name} drops to 0 HP!")
+            return log
 
     # Optional off-hand
-    t2 = _offhand_if_applicable(attacker, defender, weapon_idx=weapon_idx, armor_idx=armor_idx, rng=rng, already_loaded_this_turn=used_loading)
+    t2 = _offhand_if_applicable(
+        attacker,
+        defender,
+        weapon_idx=weapon_idx,
+        armor_idx=armor_idx,
+        rng=rng,
+        already_loaded_this_turn=used_loading,
+    )
     log.extend(t2.log)
     defender.hp -= t2.damage
     used_loading = used_loading or t2.used_loading

--- a/tests/test_extra_attack.py
+++ b/tests/test_extra_attack.py
@@ -1,0 +1,26 @@
+from grimbrain.engine.types import Combatant
+from grimbrain.engine.round import run_encounter
+from grimbrain.engine.scene import run_scene
+from grimbrain.character import Character
+
+
+def CF(swings):
+    c = Character(str_score=18, dex_score=12, proficiency_bonus=2)
+    c.attacks_per_action = swings
+    return c
+
+
+def test_round_runner_two_swings():
+    A = Combatant("Ftr", CF(2), hp=30, weapon="Longsword")
+    B = Combatant("Dummy", Character(str_score=10, dex_score=10, proficiency_bonus=2), hp=20, weapon="Mace")
+    res = run_encounter(A, B, seed=21, max_rounds=1)
+    assert res["b_hp"] < 20
+
+
+def test_loading_limits_to_one_per_action():
+    c = CF(2)
+    c.add_ammo("bolts", 1)
+    A = Combatant("Xbow", c, hp=18, weapon="Light Crossbow")
+    B = Combatant("Target", Character(str_score=10, dex_score=10, proficiency_bonus=2), hp=18, weapon="Mace")
+    res = run_scene(A, B, seed=22, max_rounds=1, start_distance_ft=30)
+    assert "\n".join(res.log).lower().count("light crossbow") == 1


### PR DESCRIPTION
## Summary
- add attacks_per_action to Character model
- allow round and scene runners to swing multiple times per action
- test extra attacks and loading weapons

## Testing
- `pytest tests/test_extra_attack.py -v --cov-fail-under=0`
- `pytest -q --no-cov` *(fails: KeyboardInterrupt/time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68b88c4c6a0c832795ab9cddfe919322