### PR TITLE
feat(grapple/shove): contested checks, prone & speed-0, AI hooks, tests, demo

### DIFF
--- a/grimbrain/engine/scene.py
+++ b/grimbrain/engine/scene.py
@@ -24,7 +24,12 @@ def _reach_ft(weapon) -> int:
 
 def _speed(cmb: Combatant) -> int:
     base = getattr(cmb.actor, "speed_ft", 30)
-    return 0 if "restrained" in cmb.conditions else base
+    return 0 if ("restrained" in cmb.conditions or "grappled" in cmb.conditions) else base
+
+
+def effective_speed(cmb: Combatant) -> int:
+    """Public helper to fetch a combatant's usable speed."""
+    return _speed(cmb)
 
 
 def _ac_for(defender: Combatant, armor_idx: ArmorIndex) -> int:

--- a/grimbrain/engine/types.py
+++ b/grimbrain/engine/types.py
@@ -48,7 +48,14 @@ class Combatant:
     concentration: Optional[str] = None  # name/label of the effect or spell
     attacks_per_action: int = 1  # <-- Add this line
     reaction_available: bool = True  # reset at start of each round
+    grappled_by: Optional[str] = None
+    proficient_athletics: bool = False
+    proficient_acrobatics: bool = False
 
     def __post_init__(self) -> None:
         if self.max_hp is None:
             self.max_hp = self.hp
+
+    def clear_grapple(self) -> None:
+        self.conditions.discard("grappled")
+        self.grappled_by = None

--- a/scripts/grapple_demo.py
+++ b/scripts/grapple_demo.py
@@ -1,0 +1,57 @@
+import random
+from pathlib import Path
+
+import typer
+
+from grimbrain.character import Character
+from grimbrain.engine.types import Combatant, Target
+from grimbrain.engine.combat import grapple_action, shove_action, resolve_attack
+from grimbrain.codex.weapons import WeaponIndex
+
+
+app = typer.Typer(help="Demo: Grapple & Shove.")
+
+
+@app.command()
+def run(seed: int = 1337) -> None:
+    rng = random.Random(seed)
+    notes: list[str] = []
+    widx = WeaponIndex.load(Path("data/weapons.json"))
+
+    fighter = Combatant(
+        name="Fighter",
+        actor=Character(str_score=16, dex_score=12, proficiency_bonus=2, proficiencies={"simple weapons", "martial weapons"}),
+        hp=22,
+        weapon="Longsword",
+        proficient_athletics=True,
+    )
+    archer = Combatant(
+        name="Archer",
+        actor=Character(str_score=10, dex_score=16, proficiency_bonus=2, proficiencies={"simple weapons", "martial weapons"}),
+        hp=14,
+        weapon="Longbow",
+        proficient_acrobatics=True,
+    )
+
+    dist = 5
+    grapple_action(fighter, archer, rng=rng, notes=notes)
+    notes.append(f"Archer grappled? {'grappled' in archer.conditions} (by {archer.grappled_by})")
+    shove_action(
+        fighter,
+        archer,
+        choice="prone",
+        rng=rng,
+        distance_ft=dist,
+        reach_threshold=5,
+        notes=notes,
+        trigger_oa_fn=lambda a, d: notes.append("[OA triggered]"),
+    )
+    tgt = Target(ac=14, hp=archer.hp, cover="none", distance_ft=dist, conditions=archer.conditions)
+    res = resolve_attack(fighter.actor, fighter.weapon, tgt, widx, rng=rng)
+    notes.extend(res["notes"])
+    print("\n".join(notes))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    app()
+

--- a/tests/test_grapple_shove.py
+++ b/tests/test_grapple_shove.py
@@ -1,0 +1,86 @@
+import random
+from pathlib import Path
+
+from grimbrain.character import Character
+from grimbrain.engine.types import Combatant, Target
+from grimbrain.engine.combat import (
+    escape_grapple_action,
+    grapple_action,
+    resolve_attack,
+    shove_action,
+)
+from grimbrain.engine.scene import effective_speed
+from grimbrain.codex.weapons import WeaponIndex
+
+
+def mk_pair():
+    a_char = Character(str_score=16, dex_score=12, proficiency_bonus=2, proficiencies={"simple weapons", "martial weapons"})
+    d_char = Character(str_score=12, dex_score=16, proficiency_bonus=2, proficiencies={"simple weapons", "martial weapons"})
+    a = Combatant(name="Grappler", actor=a_char, hp=20, weapon="Mace", proficient_athletics=True)
+    d = Combatant(name="Defender", actor=d_char, hp=18, weapon="Dagger", proficient_acrobatics=True)
+    return a, d
+
+
+def test_grapple_success_and_speed_zero():
+    rng = random.Random(101)
+    a, d = mk_pair()
+    notes: list[str] = []
+    ok = grapple_action(a, d, rng=rng, notes=notes)
+    assert ok
+    assert "grappled" in d.conditions and d.grappled_by == a.name
+    assert effective_speed(d) == 0
+
+
+def test_escape_fails_then_succeeds():
+    rng = random.Random(101)
+    a, d = mk_pair()
+    notes: list[str] = []
+    assert grapple_action(a, d, rng=rng, notes=notes)
+    allc = {a.name: a, d.name: d}
+    ok = escape_grapple_action(d, allc, rng=random.Random(222), notes=notes)
+    assert not ok
+    ok2 = escape_grapple_action(d, allc, rng=random.Random(333), notes=notes)
+    assert ok2
+    assert "grappled" not in d.conditions and d.grappled_by is None
+
+
+def test_prone_modifiers_melee_adv_ranged_disadv():
+    rng = random.Random(202)
+    atk = Character(
+        str_score=16,
+        dex_score=14,
+        proficiency_bonus=2,
+        proficiencies={"simple weapons", "martial weapons"},
+        ammo={"arrows": 5},
+    )
+    widx = WeaponIndex.load(Path("data/weapons.json"))
+    target = Target(ac=14, hp=10, cover="none", distance_ft=5, conditions={"prone"})
+    res = resolve_attack(atk, "Mace", target, widx, rng=rng)
+    assert any("prone target" in n and "advantage" in n for n in res["notes"])
+    target2 = Target(ac=14, hp=10, cover="none", distance_ft=10, conditions={"prone"})
+    res2 = resolve_attack(atk, "Longbow", target2, widx, rng=rng)
+    assert any("prone target" in n and "disadvantage" in n for n in res2["notes"])
+
+
+def test_shove_push_increases_distance_and_triggers_oa():
+    rng = random.Random(808)
+    a, d = mk_pair()
+    notes: list[str] = []
+    flag = {"oa": False}
+
+    def trigger_oa(_a, _d):
+        flag["oa"] = True
+
+    ok = shove_action(
+        a,
+        d,
+        choice="push",
+        rng=rng,
+        distance_ft=5,
+        reach_threshold=5,
+        notes=notes,
+        trigger_oa_fn=trigger_oa,
+    )
+    assert ok
+    assert flag["oa"]
+


### PR DESCRIPTION
## Summary
- add grapple/prone condition flags and escape helpers
- implement contested checks with grapple, escape, and shove actions
- prone and attacker-prone affect attack advantage; grapple drops speed to 0
- provide demo script and deterministic tests for grapple & shove

## Testing
- `pytest -q tests/test_grapple_shove.py --cov-fail-under=0`
- `python -m scripts.grapple_demo --seed 1337`
- `python -m scripts.scene_fight --seed 4242 --rounds 3 --a-weapon Longsword --b-weapon Longsword`

------
https://chatgpt.com/codex/tasks/task_e_68b9cbae569c8327995bbfcd6c379aac