### PR TITLE
feat(progress): XP/level-ups + loot + shop wired into play loop

### DIFF
--- a/grimbrain/engine/loot.py
+++ b/grimbrain/engine/loot.py
@@ -1,0 +1,16 @@
+
+from typing import Dict, List
+import random
+
+
+def roll_loot(enemies: List[str], rng: random.Random, notes: List[str]) -> Dict[str, int]:
+    names = " ".join(n.lower() for n in enemies)
+    hard = "ogre" in names
+    gold = rng.randint(1,6) * (10 if hard else 5)
+    inv: Dict[str,int] = {}
+    if rng.random() < 0.50:
+        inv["potion_healing"] = inv.get("potion_healing",0) + 1
+    if rng.random() < 0.25:
+        inv["ammo_arrows"] = inv.get("ammo_arrows",0) + 20
+    notes.append(f"Loot: +{gold} gp, items={inv or {}}")
+    return {"gold": gold, **inv}

--- a/grimbrain/engine/progression.py
+++ b/grimbrain/engine/progression.py
@@ -1,0 +1,62 @@
+from typing import Dict, List
+import random
+
+XP_THRESHOLDS = {2: 300, 3: 900, 4: 2700, 5: 6500}
+
+
+def proficiency_bonus_for_level(level: int) -> int:
+    if level >= 17:
+        return 6
+    if level >= 13:
+        return 5
+    if level >= 9:
+        return 4
+    if level >= 5:
+        return 3
+    return 2
+
+
+def xp_value_for_enemy(name: str) -> int:
+    n = name.lower()
+    if "ogre" in n:
+        return 450
+    if "orc" in n:
+        return 100
+    # goblin, wolf, skeleton, bandit baseline
+    return 50
+
+
+def award_xp(enemies: List[str], pcs: List[dict], notes: List[str]) -> Dict[str, int]:
+    total = sum(xp_value_for_enemy(n) for n in enemies)
+    living = [pc for pc in pcs if pc.get("hp", pc.get("max_hp", 0)) > 0]
+    share = total // max(1, len(living))
+    gains: Dict[str, int] = {}
+    for pc in pcs:
+        pid = pc.get("id") or pc.get("name")
+        if pc in living:
+            pc["xp"] = pc.get("xp", 0) + share
+            gains[pid] = share
+    notes.append(f"XP awarded: {total} total → {share} each to {len(living)} PC(s).")
+    return gains
+
+
+def maybe_level_up(pc: dict, rng: random.Random, notes: List[str]) -> bool:
+    leveled = False
+    while True:
+        cur = pc.get("level", 1)
+        nxt = cur + 1
+        thresh = XP_THRESHOLDS.get(nxt)
+        if not thresh or pc.get("xp", 0) < thresh:
+            break
+        pc["level"] = nxt
+        roll = max(1, rng.randint(1, 10) + pc.get("con_mod", 0))
+        pc["max_hp"] = pc.get("max_hp", 1) + roll
+        pc["hp"] = pc["max_hp"]
+        pb = proficiency_bonus_for_level(nxt)
+        pc["pb"] = pb
+        pc["prof"] = pb
+        notes.append(
+            f"{pc.get('name', 'PC')} reaches level {nxt}! +{roll} HP (max {pc['max_hp']}), PB now {pb}."
+        )
+        leveled = True
+    return leveled

--- a/grimbrain/engine/shop.py
+++ b/grimbrain/engine/shop.py
@@ -1,0 +1,50 @@
+
+from typing import Dict, List, Optional
+
+PRICES = {"potion_healing": 50, "ammo_arrows": 1, "Longsword": 10, "Scimitar": 10, "Longbow": 10}
+
+def run_shop(state: Dict, notes: List[str], rng, script_path: Optional[str] = None) -> None:
+    gold = state.setdefault("gold", 0)
+    inv = state.setdefault("inventory", {})
+    cmds: List[str] = []
+    if script_path:
+        with open(script_path, "r", encoding="utf-8") as f:
+            cmds = [line.strip() for line in f if line.strip()]
+    def buy(item: str, qty: int = 1) -> None:
+        nonlocal gold
+        price = PRICES.get(item, 0) * qty
+        if gold >= price:
+            gold -= price
+            inv[item] = inv.get(item, 0) + qty
+            notes.append(f"Bought {qty}× {item} for {price} gp.")
+        else:
+            notes.append(f"Not enough gold to buy {qty}× {item}.")
+    def sell(item: str, qty: int = 1) -> None:
+        nonlocal gold
+        have = inv.get(item, 0)
+        qty = min(qty, have)
+        if qty <= 0:
+            notes.append(f"No {item} to sell.")
+            return
+        price = int(PRICES.get(item, 0) * 0.5) * qty
+        inv[item] = have - qty
+        if inv[item] <= 0:
+            inv.pop(item, None)
+        gold += price
+        notes.append(f"Sold {qty}× {item} for {price} gp.")
+    for raw in cmds:
+        parts = raw.split()
+        if not parts:
+            continue
+        op = parts[0].lower()
+        if op == "buy" and len(parts) >= 2:
+            item = parts[1]
+            qty = int(parts[2]) if len(parts) > 2 else 1
+            buy(item, qty)
+        elif op == "sell" and len(parts) >= 2:
+            item = parts[1]
+            qty = int(parts[2]) if len(parts) > 2 else 1
+            sell(item, qty)
+        elif op == "leave":
+            break
+    state["gold"] = gold

--- a/tests/phase8/test_progression_loot_shop.py
+++ b/tests/phase8/test_progression_loot_shop.py
@@ -1,0 +1,32 @@
+import json, random, sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+from grimbrain.engine.progression import proficiency_bonus_for_level, maybe_level_up, award_xp
+from grimbrain.engine.loot import roll_loot
+from grimbrain.engine.shop import run_shop
+
+def test_pb_table():
+    assert proficiency_bonus_for_level(1) == 2
+    assert proficiency_bonus_for_level(5) == 3
+    assert proficiency_bonus_for_level(9) == 4
+
+def test_xp_award_and_levelup_deterministic():
+    pcs = [{"id": "PC1", "name": "Fighter", "level": 1, "xp": 290, "max_hp": 24, "hp": 24, "con_mod": 2, "pb": 2, "prof": 2}]
+    gains = award_xp(["Goblin"], pcs, [])
+    assert gains["PC1"] == 50
+    rng = random.Random(42)
+    leveled = maybe_level_up(pcs[0], rng, [])
+    assert leveled and pcs[0]["level"] == 2 and pcs[0]["pb"] == 2
+
+def test_loot_gold_and_items():
+    rng = random.Random(1)
+    notes = []
+    loot = roll_loot(["Ogre"], rng, notes)
+    assert "gold" in loot and loot["gold"] >= 10
+
+def test_shop_buy_sell_scripted(tmp_path):
+    state = {"gold": 60, "inventory": {}}
+    script = tmp_path / "shop.txt"
+    script.write_text("buy potion_healing\nsell potion_healing\nleave\n")
+    notes = []
+    run_shop(state, notes, random.Random(3), str(script))
+    assert state["gold"] >= 35

--- a/tests/scripts/shop_smoke.txt
+++ b/tests/scripts/shop_smoke.txt
@@ -1,0 +1,3 @@
+buy potion_healing
+sell potion_healing
+leave


### PR DESCRIPTION
## Summary
- add progression utilities: XP thresholds, proficiency bonus scaling, and level-up HP
- add deterministic loot rolls and party shop with simple buy/sell commands
- integrate XP awards, loot, level-ups, and shop flow into `play` CLI; emit JSON summaries

## Testing
- `pytest -q tests/phase8/test_progression_loot_shop.py --override-ini="addopts="`
- `pytest -q tests/phase7/test_play_cli.py --override-ini="addopts="`
- `python main.py play --pc tests/fixtures/pc_basic.json --encounter goblin --seed 7 --json --quiet < /dev/null`
- `python main.py play --pc /tmp/pc_shop.json --encounter goblin --seed 7 --shop --script tests/scripts/shop_smoke.txt`

------
https://chatgpt.com/codex/tasks/task_e_68bb256e19948327a0db74d80c791054