### PR TITLE
feat(progress): XP/level-ups + loot + shop wired into play loop

### DIFF
--- a/grimbrain/engine/loot.py
+++ b/grimbrain/engine/loot.py
@@ -6,11 +6,11 @@ import random
 def roll_loot(enemies: List[str], rng: random.Random, notes: List[str]) -> Dict[str, int]:
     names = " ".join(n.lower() for n in enemies)
     hard = "ogre" in names
-    gold = rng.randint(1,6) * (10 if hard else 5)
-    inv: Dict[str,int] = {}
-    if rng.random() < 0.50:
-        inv["potion_healing"] = inv.get("potion_healing",0) + 1
+    gold = ((rng.randint(1, 6) + rng.randint(1, 6)) * 10) if hard else rng.randint(1, 6) * 5
+    inv: Dict[str, int] = {}
+    if rng.random() < 0.5:
+        inv["potion_healing"] = inv.get("potion_healing", 0) + 1
     if rng.random() < 0.25:
-        inv["ammo_arrows"] = inv.get("ammo_arrows",0) + 20
+        inv["ammo_arrows"] = inv.get("ammo_arrows", 0) + 20
     notes.append(f"Loot: +{gold} gp, items={inv or {}}")
     return {"gold": gold, **inv}

--- a/grimbrain/play_cli.py
+++ b/grimbrain/play_cli.py
@@ -79,7 +79,11 @@ def _load_party(path: Path) -> tuple[List[Dict[str, object]], int, Dict[str, int
         pc["prof"] = pc.get("pb", 2)
         pc.setdefault("con_mod", 0)
         pc.setdefault("side", "party")
-        pc.setdefault("tags", set())
+        tags = pc.get("tags")
+        if isinstance(tags, list):
+            pc["tags"] = set(tags)
+        else:
+            pc.setdefault("tags", set())
         res.append(pc)
     return res, gold, inv
 


### PR DESCRIPTION
## Summary
- Track XP per encounter and level-up PCs, increasing HP and proficiency bonus
- Award gold and basic items post-encounter with deterministic RNG
- Support scripted shop interactions for buying and selling gear
- Load PC tags as sets to prevent effect engine crashes

## Testing
- `pre-commit run --files grimbrain/engine/loot.py grimbrain/play_cli.py tests/phase8/test_progression_loot_shop.py` *(missing `pre-commit`)*
- `pytest tests/test_effects_engine.py::test_ignite_ticks_and_expires_json tests/phase8/test_progression_loot_shop.py --maxfail=1 --disable-warnings -q --override-ini addopts=""`
- `python main.py play --pc tests/fixtures/pc_basic.json --encounter goblin --seed 7 --json --quiet --script tests/scripts/play_smoke.txt`
- `python main.py play --pc tests/fixtures/pc_basic.json --encounter goblin --seed 7 --shop --script tests/scripts/shop_smoke.txt`


------
https://chatgpt.com/codex/tasks/task_e_68bec927f9948327a61a60782fbbadf2