### PR TITLE
Fix PC basic HP and update golden outputs

### DIFF
--- a/tests/fixtures/pc_basic.json
+++ b/tests/fixtures/pc_basic.json
@@ -2,7 +2,7 @@
   "party": [
     {
       "name": "Hero",
-      "hp": -8,
+      "hp": 10,
       "ac": 10,
       "max_hp": 10,
       "mods": {

--- a/tests/golden/attack_summary_json.golden
+++ b/tests/golden/attack_summary_json.golden
@@ -1,1 +1,1 @@
-{"event": "summary", "rounds": 4, "alive": ["Hero", "Goblin"], "dead": [], "stable": []}
+{"event": "summary", "rounds": 4, "alive": ["Hero", "Goblin"], "dead": [], "stable": [], "xp_gain": {"Hero": 50}, "leveled": [], "loot": {"gold": 45, "potion_healing": 3, "ammo_arrows": 60}}

--- a/tests/golden/hide_full_pretty.golden
+++ b/tests/golden/hide_full_pretty.golden
@@ -4,3 +4,5 @@ Not found verb: "hide"
 Not found verb: "status"
 Not found verb: "end"
 Summary: rounds=4; alive=['Hero', 'Goblin']; dead=[]; stable=[]
+XP awarded: 50 total -> 50 each to 1 PC(s).
+Loot: +15 gp, items={}


### PR DESCRIPTION
## Summary
- ensure test PC starts at full health
- update golden outputs reflecting XP and loot

## Testing
- `pytest -q` *(fails: Required test coverage of 70% not reached. Total coverage: 35.02%)*

------
https://chatgpt.com/codex/tasks/task_e_68c0749611e08327ab506e5bf6698bbf