### PR TITLE
Award experience and randomize travel encounters

### DIFF
--- a/grimbrain/scripts/campaign_play.py
+++ b/grimbrain/scripts/campaign_play.py
@@ -20,10 +20,16 @@ def travel(load: str = typer.Option(..., "--load"), hours: int = 4, seed: int | 
     notes = []
     advance_time(st, hours=hours)
     res = run_encounter(st, rng, notes)
+    st.seed = rng.randint(0, int(1e9))
     save_campaign(st, load)
     print(f"Day {st.day} {st.time_of_day} @ {st.location}")
-    print("\n".join(notes))
-    print(res)
+    if res.get("encounter"):
+        outcome = (
+            "Victory!" if res.get("winner") == "A" else "Defeat" if res.get("winner") == "B" else "Stalemate"
+        )
+        print(f"Encounter: {res['encounter']} – {outcome}")
+    if notes:
+        print("\n".join(notes))
 
 
 @app.command()


### PR DESCRIPTION
## Summary
- Grant XP to surviving party members after victorious encounters and level up PCs when thresholds are reached
- Randomize travel by reseeding campaign state and print clear encounter outcomes

## Testing
- `pytest tests/test_campaign_core.py::test_travel_encounter_persists_hp --no-cov -q`
- `python -m grimbrain.scripts.campaign_play travel --load demo_campaign.json --hours 4 --seed 2`
- `python -m grimbrain.scripts.campaign_play travel --load demo_campaign.json --hours 4`

------
https://chatgpt.com/codex/tasks/task_e_68c17990eda48327b8b1408fc4cf6c7b