### PR TITLE
Add narrator system with story flags and templating

### DIFF
--- a/grimbrain/engine/narrator.py
+++ b/grimbrain/engine/narrator.py
@@ -1,0 +1,39 @@
+"""Narration utilities for rendering scene text."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+
+class TemplateNarrator:
+    """Simple, local narrator that performs inline template replacement."""
+
+    def render(self, template: str, ctx: Dict[str, object]) -> str:
+        """Render *template* by replacing ``{{key}}`` tokens using *ctx* values."""
+
+        out = template
+        for key, value in ctx.items():
+            out = out.replace(f"{{{{{key}}}}}", str(value))
+        return out
+
+
+def get_narrator():
+    """Return the active narrator implementation.
+
+    The local template narrator is always available. An AI-backed narrator can be
+    enabled by setting ``GRIMBRAIN_AI=1`` along with an API key environment
+    variable. If the AI narrator cannot be initialised we silently fall back to
+    the local implementation.
+    """
+
+    if os.getenv("GRIMBRAIN_AI") == "1" and (
+        os.getenv("OPENAI_API_KEY") or os.getenv("ANTHROPIC_API_KEY")
+    ):
+        try:
+            from .narrator_ai import AINarrator
+
+            return AINarrator()
+        except Exception:
+            pass
+    return TemplateNarrator()

--- a/grimbrain/engine/narrator_ai.py
+++ b/grimbrain/engine/narrator_ai.py
@@ -1,0 +1,15 @@
+"""Placeholder AI narrator implementation."""
+
+from __future__ import annotations
+
+
+class AINarrator:
+    """Stub narrator that currently defers to the local template renderer."""
+
+    def render(self, template: str, ctx):  # type: ignore[override]
+        # A future implementation can call an external model here. For now we
+        # fall back to the template narrator so that behaviour remains local and
+        # deterministic when AI mode is enabled.
+        from .narrator import TemplateNarrator
+
+        return TemplateNarrator().render(template, ctx)


### PR DESCRIPTION
## Summary
- add a local-first TemplateNarrator helper with optional AI narrator fallback
- extend YAML campaign scenes with flag requirements, set_flags, and conditional text
- update the story command to render through the narrator, manage flags, and persist campaign state

## Testing
- pytest *(fails: requires pytest-cov plugin in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c85740d53c832798014a059e081e17