### PR TITLE
Explicitly set GB_ENGINE for CLI tests

### DIFF
--- a/tests/test_effects_engine.py
+++ b/tests/test_effects_engine.py
@@ -6,7 +6,7 @@ MAIN = ROOT / "main.py"
 
 def run_play(script, seed=7, json_mode=True, packs="packs/test_effects"):
     env = os.environ.copy()
-    env.setdefault("GB_ENGINE", "data")
+    env["GB_ENGINE"] = "data"
     env.setdefault("GB_RULES_DIR", "rules")
     env.setdefault("GB_CHROMA_DIR", ".chroma")
     env.setdefault("GB_RESOLVER_WARM_COUNT", "0")

--- a/tests/test_golden_effects.py
+++ b/tests/test_golden_effects.py
@@ -12,7 +12,7 @@ GOLDEN = ROOT / "tests" / "golden"
 
 def test_burning_pretty_golden():
     env = os.environ.copy()
-    env.setdefault("GB_ENGINE", "data")
+    env["GB_ENGINE"] = "data"
     env.setdefault("GB_RULES_DIR", "rules")
     env.setdefault("GB_CHROMA_DIR", ".chroma")
     env.setdefault("GB_RESOLVER_WARM_COUNT", "0")


### PR DESCRIPTION
## Summary
- ensure the CLI integration tests explicitly set `GB_ENGINE` to "data" so the dispatcher runs even when the host environment defines another engine

## Testing
- pytest --no-cov tests/test_effects_engine.py::test_ignite_ticks_and_expires_json
- pytest --no-cov tests/test_golden_effects.py::test_burning_pretty_golden

------
https://chatgpt.com/codex/tasks/task_e_68c9b8b77a8483279544286e82032a60