### PR TITLE
Improve score parsing CLI UX

### DIFF
--- a/grimbrain/engine/characters.py
+++ b/grimbrain/engine/characters.py
@@ -40,17 +40,29 @@ def _parse_scores_from_array(array_csv: str) -> Dict[str, int]:
     return dict(zip(ABILS, values_sorted))
 
 
-def _parse_scores_from_kv(kv_csv: str) -> Dict[str, int]:
+def _parse_scores_from_kv(kv: str) -> Dict[str, int]:
+    """
+    Accepts either:
+      - "STR=10 DEX=15 CON=14 INT=12 WIS=10 CHA=8" (space-separated)
+      - "STR=10,DEX=15,CON=14,INT=12,WIS=10,CHA=8" (comma-separated)
+    """
+
     results: Dict[str, int] = {}
-    for pair in kv_csv.replace(",", " ").split():
+    tokens: list[str] = []
+    for chunk in kv.split(","):
+        tokens.extend(chunk.strip().split())
+
+    for pair in tokens:
         if "=" not in pair:
             continue
         key, value = pair.split("=", 1)
         key = key.strip().upper()
         results[key] = int(value)
+
     for ability in ABILS:
         if ability not in results:
-            raise ValueError(f"Missing {ability} in --scores")
+            raise ValueError(f"Missing {ability} in scores (have {sorted(results)})")
+
     return results
 
 


### PR DESCRIPTION
## Summary
- allow ability score parser to accept either comma- or space-separated key/value strings and report missing abilities clearly
- add a repeatable `--score` option, improved `--scores` help text, and keep the legacy `new` subcommand entrypoint working

## Testing
- `PYTHONPATH="/tmp/stubs:$PYTHONPATH" python grimbrain/scripts/characters.py new --name Bryn --class Rogue --scores "STR=10 DEX=15 CON=14 INT=12 WIS=10 CHA=8" --point-buy 27 --weapon Shortbow --ranged true`
- `PYTHONPATH="/tmp/stubs:$PYTHONPATH" python grimbrain/scripts/characters.py new --name Bryn --class Rogue --score STR=10 --score DEX=15 --score CON=14 --score INT=12 --score WIS=10 --score CHA=8 --point-buy 27 --weapon Shortbow --ranged true`


------
https://chatgpt.com/codex/tasks/task_e_68cd6d364c648327b666e3bb384e0deb