### PR TITLE
Add campaign journal logging and CLI

### DIFF
--- a/grimbrain/engine/campaign.py
+++ b/grimbrain/engine/campaign.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import json
 import yaml
 
@@ -194,6 +194,7 @@ class CampaignState:
     # PR49: rest timing knobs
     short_rest_hours: int = 4
     long_rest_to_morning: bool = True
+    journal: List[Dict[str, Any]] = field(default_factory=list)
 
 
 def load_campaign(path: str) -> CampaignState:
@@ -217,6 +218,7 @@ def load_campaign(path: str) -> CampaignState:
         encounter_clock_step=raw.get("encounter_clock_step", 10),
         short_rest_hours=raw.get("short_rest_hours", 4),
         long_rest_to_morning=raw.get("long_rest_to_morning", True),
+        journal=raw.get("journal", []) or [],
     )
     if not st.current_hp:
         for p in st.party:

--- a/grimbrain/engine/encounters.py
+++ b/grimbrain/engine/encounters.py
@@ -88,4 +88,9 @@ def run_encounter(
                 continue
             state.inventory[item] = state.inventory.get(item, 0) + qty
 
-    return {"encounter": table["name"], "winner": winner, "loot": loot}
+    return {
+        "encounter": table["name"],
+        "winner": winner,
+        "loot": loot,
+        "rounds": res.get("rounds"),
+    }

--- a/grimbrain/engine/journal.py
+++ b/grimbrain/engine/journal.py
@@ -1,0 +1,36 @@
+"""Journal logging utilities for campaign state."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+
+def _ensure_journal(state: Any) -> list[Dict[str, Any]]:
+    journal = getattr(state, "journal", None)
+    if journal is None:
+        journal = []
+        setattr(state, "journal", journal)
+    return journal
+
+
+def log_event(
+    state: Any,
+    text: str,
+    *,
+    kind: str = "info",
+    extra: Dict[str, Any] | None = None,
+) -> None:
+    """Append a single journal entry including campaign context."""
+
+    journal = _ensure_journal(state)
+    entry: Dict[str, Any] = {
+        "ts": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "day": getattr(state, "day", 1),
+        "time": getattr(state, "time_of_day", "morning"),
+        "loc": getattr(state, "location", "Wilderness"),
+        "kind": kind,
+        "text": text.strip(),
+    }
+    if extra:
+        entry["extra"] = extra
+    journal.append(entry)

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,6 @@ addopts = -q --maxfail=1 --disable-warnings
     --cov=grimbrain.engine.skirmish
     --cov=grimbrain.scripts.campaign_play
     --cov-report=term-missing --cov-fail-under=60
-python_files = tests/test_*.py
+python_files = tests/test_*.py tests/phase*/test_*.py
 filterwarnings =
     ignore::DeprecationWarning

--- a/tests/phase9/test_journal.py
+++ b/tests/phase9/test_journal.py
@@ -1,0 +1,103 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from grimbrain.engine.campaign import CampaignState, PartyMemberRef
+from grimbrain.engine.journal import log_event
+from grimbrain.engine.campaign import save_campaign, load_campaign
+from grimbrain.scripts import campaign_play
+
+
+def test_log_event_persists_and_formats():
+    st = CampaignState(
+        seed=1,
+        party=[
+            PartyMemberRef(
+                id="PC1",
+                name="Fighter",
+                str_mod=3,
+                dex_mod=1,
+                con_mod=2,
+                int_mod=0,
+                wis_mod=0,
+                cha_mod=0,
+                ac=16,
+                max_hp=24,
+                pb=2,
+                speed=30,
+                weapon_primary="Longsword",
+            )
+        ],
+    )
+    assert st.journal == []
+    log_event(st, "Travel 4h; No encounter", kind="travel", extra={"effective": 30})
+    log_event(st, "Short rest", kind="rest", extra={"type": "short"})
+    assert len(st.journal) == 2
+    assert st.journal[0]["kind"] == "travel"
+    assert "No encounter" in st.journal[0]["text"]
+    assert st.journal[1]["extra"]["type"] == "short"
+
+
+def test_cli_logging_and_journal_command(tmp_path, monkeypatch, capsys):
+    st = CampaignState(
+        seed=5,
+        party=[
+            PartyMemberRef(
+                id="PC1",
+                name="Scout",
+                str_mod=1,
+                dex_mod=2,
+                con_mod=1,
+                int_mod=0,
+                wis_mod=0,
+                cha_mod=0,
+                ac=13,
+                max_hp=12,
+                pb=2,
+                speed=30,
+                weapon_primary="Bow",
+            )
+        ],
+    )
+    st.current_hp["PC1"] = 8
+    path = tmp_path / "camp.json"
+    save_campaign(st, str(path))
+
+    results = iter(
+        [
+            {"encounter": "Bandits", "winner": "A", "rounds": 2},
+            {"encounter": None},
+        ]
+    )
+
+    def fake_run_encounter(state, rng, notes, force=False):
+        return next(results, {"encounter": None})
+
+    monkeypatch.setattr(campaign_play, "run_encounter", fake_run_encounter)
+    campaign_play.travel(load=str(path), hours=4, seed=1, force_encounter=False, encounter_chance=None)
+    campaign_play.travel(load=str(path), hours=4, seed=2, force_encounter=False, encounter_chance=None)
+    campaign_play.short_rest(load=str(path), seed=3)
+    campaign_play.long_rest(load=str(path))
+    campaign_play.quest(load=str(path), add="Find the relic", done=None)
+    campaign_play.quest(load=str(path), add=None, done="Q1")
+    capsys.readouterr()
+
+    loaded = load_campaign(str(path))
+    kinds = [e["kind"] for e in loaded.journal]
+    assert kinds.count("travel") == 2
+    assert any("Encounter" in e["text"] for e in loaded.journal if e["kind"] == "travel")
+    assert any("No encounter" in e["text"] for e in loaded.journal if e["kind"] == "travel")
+    assert any(e["kind"] == "rest" for e in loaded.journal)
+    assert any(e["kind"] == "quest" and "Find the relic" in e["text"] for e in loaded.journal)
+
+    campaign_play.journal(load=str(path), tail=10, grep=None, clear=False)
+    out = capsys.readouterr().out
+    assert "(travel)" in out
+    assert "Day" in out
+
+    campaign_play.journal(load=str(path), tail=None, grep=None, clear=True)
+    cleared_out = capsys.readouterr().out
+    assert "Journal cleared" in cleared_out
+    cleared_state = load_campaign(str(path))
+    assert cleared_state.journal == []


### PR DESCRIPTION
## Summary
- add a reusable journal logger that snapshots day, time, location, and metadata to campaign state
- persist the journal on the campaign state, expose the entries through travel, rest, story, quest, and shop flows, and add a CLI reader
- update encounter results to expose round counts and expand pytest discovery with new journal tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cd94c8ccd88327bde29654a4205c9b