### PR TITLE
Handle pytest-cov option conflicts

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,21 +1,40 @@
 """Test helpers for environments without optional pytest plugins."""
 
+import argparse
+import importlib.util
+
+
+def _addoption_if_missing(group, *args, **kwargs):
+    try:
+        group.addoption(*args, **kwargs)
+    except argparse.ArgumentError:
+        # pytest-cov (or another plugin) already registered this option.
+        # Avoid raising during test discovery when coverage support is available.
+        pass
+
 
 def pytest_addoption(parser):
+    if importlib.util.find_spec("pytest_cov") is not None:
+        # pytest-cov is installed; it will register these options itself.
+        return
+
     group = parser.getgroup("coverage", "coverage reporting")
-    group.addoption(
+    _addoption_if_missing(
+        group,
         "--cov",
         action="append",
         default=[],
         help="(noop) accepted for compatibility when pytest-cov is unavailable.",
     )
-    group.addoption(
+    _addoption_if_missing(
+        group,
         "--cov-report",
         action="append",
         default=[],
         help="(noop) accepted for compatibility when pytest-cov is unavailable.",
     )
-    group.addoption(
+    _addoption_if_missing(
+        group,
         "--cov-fail-under",
         action="store",
         default=None,


### PR DESCRIPTION
## Summary
- add safeguards so the coverage compatibility shim defers to pytest-cov when it is installed
- gracefully handle attempts to re-register coverage arguments when pytest-cov is absent

## Testing
- pytest -q *(fails: ImportError: cannot import name 'ConfigDict' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68d434b9cbc48327a51427ed939b73d3