### PR TITLE
Add racial features, lucky rerolls, and darkness handling

### DIFF
--- a/grimbrain/engine/campaign.py
+++ b/grimbrain/engine/campaign.py
@@ -10,6 +10,7 @@ from ..models import PC, MonsterSidecar
 from .combat import run_encounter as _run_encounter
 from .encounter import apply_difficulty
 from ..campaign import load_party_file
+from .types import Combatant
 
 
 @dataclass
@@ -175,6 +176,8 @@ class PartyMemberRef:
     background: Optional[str] = None
     languages: List[str] = field(default_factory=list)
     tool_profs: List[str] = field(default_factory=list)
+    features: Dict[str, Any] = field(default_factory=dict)
+    light_emitter: bool = False
 
 
 @dataclass
@@ -205,6 +208,7 @@ class CampaignState:
     short_rest_hours: int = 4
     long_rest_to_morning: bool = True
     journal: List[Dict[str, Any]] = field(default_factory=list)
+    light_level: str = "normal"
 
     def normalize_inventory(self) -> None:
         """Ensure the inventory is stored as a mapping of item → quantity."""
@@ -245,6 +249,7 @@ def load_campaign(path: str) -> CampaignState:
         short_rest_hours=raw.get("short_rest_hours", 4),
         long_rest_to_morning=raw.get("long_rest_to_morning", True),
         journal=raw.get("journal", []) or [],
+        light_level=raw.get("light_level", "normal"),
     )
     if not st.current_hp:
         for p in st.party:
@@ -276,6 +281,7 @@ def party_to_combatants(state: CampaignState) -> Dict[str, Combatant]:
         c = make_combatant_from_party_member(p, team="A", cid=p.id)
         c.hp = state.current_hp.get(p.id, p.max_hp)
         c.max_hp = p.max_hp
+        c.environment_light = getattr(state, "light_level", "normal")
         res[p.id] = c
     return res
 

--- a/grimbrain/engine/characters.py
+++ b/grimbrain/engine/characters.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict
-from typing import Dict, List, Set
+from typing import Any, Dict, List, Set
 from pathlib import Path
 import json
 import random
@@ -105,6 +105,7 @@ def build_partymember(
     background: str | None = None,
     languages: List[str] | None = None,
     tool_profs: List[str] | None = None,
+    features: Dict[str, Any] | None = None,
 ) -> PartyMemberRef:
     cls_l = cls.lower()
     hit_die = HIT_DICE.get(cls_l, 8)
@@ -143,6 +144,16 @@ def build_partymember(
     prof_saves_set = sorted(set(prof_saves or []))
     has_athletics = "Athletics" in prof_skills_set
     has_acrobatics = "Acrobatics" in prof_skills_set
+    feature_data: Dict[str, Any] = {}
+    if features:
+        for key, value in features.items():
+            if isinstance(value, list):
+                feature_data[key] = list(value)
+            elif isinstance(value, dict):
+                feature_data[key] = dict(value)
+            else:
+                feature_data[key] = value
+
     return PartyMemberRef(
         id=name,
         name=name,
@@ -161,6 +172,7 @@ def build_partymember(
         background=background,
         languages=sorted(languages or []),
         tool_profs=sorted(tool_profs or []),
+        features=feature_data,
         prof_athletics=has_athletics,
         prof_acrobatics=has_acrobatics,
         **mods,

--- a/grimbrain/engine/death.py
+++ b/grimbrain/engine/death.py
@@ -1,5 +1,5 @@
 import random
-from .types import DeathState
+from .types import DeathState, roll_d20
 
 
 def reset_death_state(ds: DeathState) -> None:
@@ -8,10 +8,10 @@ def reset_death_state(ds: DeathState) -> None:
     ds.dead = False
 
 
-def roll_death_save(ds: DeathState, rng: random.Random) -> str:
+def roll_death_save(ds: DeathState, rng: random.Random, pm=None) -> str:
     if ds.stable or ds.dead:
         return "no-op"
-    d = rng.randint(1, 20)
+    d = roll_d20(rng, pm=pm)
     if d == 1:
         ds.failures += 2
         outcome = "crit-fail"

--- a/grimbrain/engine/encounters.py
+++ b/grimbrain/engine/encounters.py
@@ -47,7 +47,9 @@ def run_encounter(
         return {"encounter": None}
     enemies: List[Combatant] = []
     for idx, ename in enumerate(table["enemies"], 1):
-        enemies.append(_enemy_to_combatant(ename, idx))
+        cmb = _enemy_to_combatant(ename, idx)
+        cmb.environment_light = getattr(state, "light_level", "normal")
+        enemies.append(cmb)
     roster = list(allies_map.values()) + enemies
     res = run_skirmish(roster, seed=rng.randint(1, 999999))
     apply_combat_results(state, allies_map)

--- a/grimbrain/engine/round.py
+++ b/grimbrain/engine/round.py
@@ -90,7 +90,9 @@ def _attack_once(attacker: Combatant, defender: Combatant, wname: str, *,
         weapon_idx,
         base_mode="none", power=power, offhand=False, two_handed=False,
         has_fired_loading_weapon_this_turn=already_loaded_this_turn,
-        rng=rng
+        rng=rng,
+        attacker_state=attacker,
+        defender_state=defender,
     )
 
     if not res["ok"]:
@@ -134,7 +136,9 @@ def _offhand_if_applicable(attacker: Combatant, defender: Combatant, *,
         weapon_idx,
         base_mode="none", power=False, offhand=True, two_handed=False,
         has_fired_loading_weapon_this_turn=already_loaded_this_turn,
-        rng=rng
+        rng=rng,
+        attacker_state=attacker,
+        defender_state=defender,
     )
     if not res["ok"]:
         return TurnResult(log, 0, False, False)
@@ -158,7 +162,7 @@ def take_turn(attacker: Combatant, defender: Combatant, *,
 
     # Start-of-turn death save if attacker is down
     if attacker.hp <= 0 and not attacker.death.stable and not attacker.death.dead:
-        outcome = roll_death_save(attacker.death, rng)
+        outcome = roll_death_save(attacker.death, rng, pm=attacker)
         log.append(f"{attacker.name} death save: {outcome}")
         if attacker.death.dead:
             log.append(f"{attacker.name} dies.")

--- a/grimbrain/engine/scene.py
+++ b/grimbrain/engine/scene.py
@@ -81,6 +81,8 @@ def _maybe_opportunity_attack(
             two_handed=False,
             has_fired_loading_weapon_this_turn=False,
             rng=rng,
+            attacker_state=reactor,
+            defender_state=mover,
         )
         if not res["ok"]:
             log.append(f"  OA not possible: {res.get('reason')}")
@@ -123,7 +125,7 @@ def _take_scene_turn(attacker: Combatant, defender: Combatant, *,
     """
     log: List[str] = []
     if attacker.hp <= 0 and not attacker.death.stable and not attacker.death.dead:
-        outcome = roll_death_save(attacker.death, rng)
+        outcome = roll_death_save(attacker.death, rng, pm=attacker)
         log.append(f"{attacker.name} death save: {outcome}")
         if attacker.death.dead:
             log.append(f"{attacker.name} dies.")
@@ -400,6 +402,8 @@ def _take_scene_turn(attacker: Combatant, defender: Combatant, *,
             two_handed=False,
             has_fired_loading_weapon_this_turn=False,
             rng=rng,
+            attacker_state=attacker,
+            defender_state=defender,
         )
         if not res["ok"]:
             log.append(f"{attacker.name} cannot attack: {res['reason']}")

--- a/grimbrain/engine/util.py
+++ b/grimbrain/engine/util.py
@@ -21,6 +21,7 @@ def make_combatant_from_party_member(p: PartyMemberRef, *, team: str, cid: str) 
         equipped_armor=p.armor,
         equipped_shield=p.shield,
     )
+    features = dict(getattr(p, "features", {}) or {})
     cmb = Combatant(
         id=cid,
         name=p.name,
@@ -45,5 +46,15 @@ def make_combatant_from_party_member(p: PartyMemberRef, *, team: str, cid: str) 
         stealth_disadvantage=p.stealth_disadv,
         prof_skills=set(p.prof_skills or []),
         prof_saves=set(p.prof_saves or []),
+        features=features,
+        light_emitter=bool(getattr(p, "light_emitter", False)),
     )
+    actor.features = features
+    resist = features.get("resist")
+    if resist:
+        cmb.resist.update(str(r).lower() for r in resist)
+    adv_tags = features.get("adv_saves_tags")
+    if adv_tags:
+        cmb.advantage_save_tags.update(str(tag).lower() for tag in adv_tags)
+        actor.adv_saves_tags = [str(tag).lower() for tag in adv_tags]
     return cmb

--- a/grimbrain/scripts/characters.py
+++ b/grimbrain/scripts/characters.py
@@ -271,6 +271,15 @@ def create(
         list(back_info.languages) if back_info else [],
     )
     tool_profs = merge_unique([], list(back_info.tools) if back_info else [])
+    features: dict[str, object] = {}
+    race_lower = (race or "").lower()
+    if race_lower == "elf":
+        features["darkvision"] = 60
+    if race_lower == "dwarf":
+        features.setdefault("resist", []).append("poison")
+        features.setdefault("adv_saves_tags", []).append("poison")
+    if race_lower == "halfling":
+        features["lucky"] = True
 
     summary = pc_summary_line(name, klass, scores_final, weapon, ranged_bool)
     typer.echo(f"\n{summary}")
@@ -299,6 +308,7 @@ def create(
         background=background,
         languages=languages,
         tool_profs=tool_profs,
+        features=features,
     )
     out_path = out or _default_pc_path(name)
     save_pc(pc, out_path)

--- a/tests/phase14/test_darkvision_and_poison.py
+++ b/tests/phase14/test_darkvision_and_poison.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+import random
+
+from grimbrain.engine.characters import build_partymember
+from grimbrain.engine.util import make_combatant_from_party_member
+from grimbrain.engine.combat import resolve_attack
+from grimbrain.engine.types import Target
+from grimbrain.engine.damage import apply_defenses
+from grimbrain.engine.saves import roll_save
+from grimbrain.codex.weapons import WeaponIndex
+
+
+class FixedRandom(random.Random):
+    def __init__(self, sequence):
+        super().__init__()
+        self._sequence = list(sequence)
+
+    def randint(self, a, b):  # noqa: D401 - deterministic sequence helper
+        return self._sequence.pop(0)
+
+
+def _make_combatant(pm, *, team="A"):
+    cmb = make_combatant_from_party_member(pm, team=team, cid=pm.id)
+    return cmb
+
+
+def test_darkness_disadvantage_without_darkvision():
+    idx = WeaponIndex.load(Path("data/weapons.json"))
+    attacker = build_partymember(
+        name="Attacker",
+        cls="Fighter",
+        scores={"STR": 16, "DEX": 10, "CON": 14, "INT": 10, "WIS": 10, "CHA": 8},
+        weapon="Longsword",
+        ranged=False,
+    )
+    defender = build_partymember(
+        name="Defender",
+        cls="Fighter",
+        scores={"STR": 12, "DEX": 10, "CON": 12, "INT": 10, "WIS": 10, "CHA": 10},
+        weapon="Spear",
+        ranged=False,
+    )
+    atk_cmb = _make_combatant(attacker)
+    def_cmb = _make_combatant(defender)
+    atk_cmb.environment_light = "dark"
+    def_cmb.environment_light = "dark"
+    res = resolve_attack(
+        atk_cmb.actor,
+        attacker.weapon_primary,
+        Target(ac=def_cmb.ac, hp=def_cmb.hp),
+        idx,
+        base_mode="none",
+        rng=random.Random(1),
+        forced_d20=(12, 7),
+        attacker_state=atk_cmb,
+        defender_state=def_cmb,
+    )
+    assert res["mode"] == "disadvantage"
+    assert any("darkness" in note for note in res.get("notes", []))
+
+
+def test_darkvision_negates_darkness_penalty():
+    idx = WeaponIndex.load(Path("data/weapons.json"))
+    attacker = build_partymember(
+        name="Seer",
+        cls="Fighter",
+        scores={"STR": 16, "DEX": 10, "CON": 14, "INT": 10, "WIS": 10, "CHA": 8},
+        weapon="Longsword",
+        ranged=False,
+        features={"darkvision": 60},
+    )
+    defender = build_partymember(
+        name="Target",
+        cls="Fighter",
+        scores={"STR": 12, "DEX": 10, "CON": 12, "INT": 10, "WIS": 10, "CHA": 10},
+        weapon="Spear",
+        ranged=False,
+    )
+    atk_cmb = _make_combatant(attacker)
+    def_cmb = _make_combatant(defender)
+    atk_cmb.environment_light = "dark"
+    res = resolve_attack(
+        atk_cmb.actor,
+        attacker.weapon_primary,
+        Target(ac=def_cmb.ac, hp=def_cmb.hp),
+        idx,
+        base_mode="none",
+        rng=random.Random(2),
+        forced_d20=(12, 7),
+        attacker_state=atk_cmb,
+        defender_state=def_cmb,
+    )
+    assert res["mode"] == "none"
+
+
+def test_poison_resistance_halves_damage():
+    pm = build_partymember(
+        name="Brokk",
+        cls="Fighter",
+        scores={"STR": 16, "DEX": 10, "CON": 14, "INT": 10, "WIS": 10, "CHA": 8},
+        weapon="Warhammer",
+        ranged=False,
+        features={"resist": ["poison"]},
+    )
+    cmb = _make_combatant(pm)
+    final, notes, _ = apply_defenses(10, "poison", cmb)
+    assert final == 5
+    assert any("resistant" in note for note in notes)
+
+
+def test_advantage_on_poison_saves():
+    pm = build_partymember(
+        name="Stone",
+        cls="Fighter",
+        scores={"STR": 16, "DEX": 10, "CON": 14, "INT": 10, "WIS": 10, "CHA": 8},
+        weapon="Warhammer",
+        ranged=False,
+        features={"adv_saves_tags": ["poison"]},
+    )
+    cmb = _make_combatant(pm)
+    ok_plain, die_plain, (plain1, plain2) = roll_save(
+        cmb.actor, "CON", 10, rng=FixedRandom([3, 15]), combatant=cmb
+    )
+    rng_adv = FixedRandom([3, 15])
+    ok_adv, die_adv, (adv1, adv2) = roll_save(
+        cmb.actor, "CON", 10, rng=rng_adv, combatant=cmb, tag="poison"
+    )
+    assert plain1 == 3 and die_plain == 3
+    assert ok_plain is ((plain1 + cmb.con_mod) >= 10)
+    assert adv1 == 3 and adv2 == 15 and die_adv == 15
+    assert ok_adv is (15 + cmb.con_mod >= 10)

--- a/tests/phase14/test_race_features.py
+++ b/tests/phase14/test_race_features.py
@@ -1,0 +1,42 @@
+import random
+
+from grimbrain.engine.characters import build_partymember
+from grimbrain.engine.types import roll_d20
+
+
+class SequenceRandom(random.Random):
+    def __init__(self, sequence):
+        super().__init__()
+        self._sequence = list(sequence)
+
+    def randint(self, a, b):  # noqa: D401 - deterministic sequence helper
+        return self._sequence.pop(0)
+
+
+def test_halfling_lucky_rerolls_one():
+    pm = build_partymember(
+        name="Hal",
+        cls="Rogue",
+        scores={"STR": 8, "DEX": 14, "CON": 10, "INT": 10, "WIS": 10, "CHA": 10},
+        weapon="Shortbow",
+        ranged=True,
+        features={"lucky": True},
+    )
+    rng = SequenceRandom([1, 7])
+    notes: list[str] = []
+    result = roll_d20(rng, pm=pm, log=notes)
+    assert result == 7
+    assert notes and "lucky" in notes[0]
+
+
+def test_roll_d20_without_lucky_keeps_one():
+    pm = build_partymember(
+        name="NoLuck",
+        cls="Fighter",
+        scores={"STR": 15, "DEX": 10, "CON": 14, "INT": 10, "WIS": 10, "CHA": 8},
+        weapon="Longsword",
+        ranged=False,
+    )
+    rng = SequenceRandom([1])
+    result = roll_d20(rng, pm=pm)
+    assert result == 1


### PR DESCRIPTION
## Summary
- extend party members and combatants with racial feature metadata and propagate it during character creation
- apply darkvision, poison resilience, and halfling Lucky during combat, saves, and story checks with a new encounter light-level toggle
- add regression tests covering Lucky rerolls, darkness disadvantage, poison resistance, and advantage on tagged saves

## Testing
- pytest tests/phase14/test_race_features.py tests/phase14/test_darkvision_and_poison.py tests/test_death_saves.py tests/test_combat_engine.py tests/test_skirmish.py

------
https://chatgpt.com/codex/tasks/task_e_68d57b132f108327ad95864b37cf59fc