### PR TITLE
Fix warhammer weapon definition

### DIFF
--- a/data/weapons.json
+++ b/data/weapons.json
@@ -160,14 +160,11 @@
     "properties": ["two-handed"]
   },
   {
-     "name": "Warhammer",
-     "type": "martial",
-     "category": "melee",
-     "damage": "1d8",
-     "damage_type": "bludgeoning",
-     "properties": ["versatile"],
-     "versatile": "1d10",
-     "weight": 2,
-     "cost": "15 gp"
-   }
+    "name": "Warhammer",
+    "category": "martial",
+    "kind": "melee",
+    "damage": "1d8",
+    "damage_type": "bludgeoning",
+    "properties": ["versatile:1d10"]
+  }
 ]


### PR DESCRIPTION
## Summary
- correct the Warhammer entry in data/weapons.json to use the expected category/kind fields and versatile damage property

## Testing
- pytest *(fails: tests/test_story_mode.py::test_story_sample expects a story path argument)*

------
https://chatgpt.com/codex/tasks/task_e_68d69d24f44c83278fcc2134f809b4fe