### PR TITLE
Handle direct story invocation binding

### DIFF
--- a/grimbrain/scripts/campaign_play.py
+++ b/grimbrain/scripts/campaign_play.py
@@ -548,6 +548,16 @@ def story(
 ):
     """Play a scripted story scene-by-scene, tracking simple campaign flags."""
 
+    # When invoked via Typer the first argument will be a Context instance, but
+    # our unit tests call story("path.yaml") directly. In that scenario Typer's
+    # injection happens at runtime so the positional argument intended for
+    # ``file`` ends up bound to ``ctx``. Detect that case and shuffle the value
+    # back to the ``file`` parameter so the remainder of the logic can operate on
+    # normalized strings.
+    if isinstance(ctx, str) and (file is None or isinstance(file, ArgumentInfo)):
+        file = ctx
+        ctx = None
+
     load_path = _cli_value(load)
     story_path = _cli_value(story)
     file_path = _cli_value(file)


### PR DESCRIPTION
## Summary
- normalize the Typer context parameter so direct story() calls accept a file path
- keep the remainder of the command logic unchanged for CLI use

## Testing
- pytest tests/test_story_mode.py::test_story_sample *(fails: coverage fail-under 60 when running only this test)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a80fe80c8327a19b801ba335ec9c