### PR TITLE
Improve AI cache with structured keys and index

### DIFF
--- a/grimbrain/engine/narrator_ai.py
+++ b/grimbrain/engine/narrator_ai.py
@@ -1,5 +1,5 @@
 import json, urllib.request, urllib.error, sys, time
-from .narrator import TemplateNarrator, ai_cached_generate
+from .narrator import TemplateNarrator, ai_cached_generate_v2
 
 class AINarrator:
     KIND = "openai:gpt-4o-mini"
@@ -62,11 +62,23 @@ class AINarrator:
                 print(f"[narration] ERROR {type(e).__name__}: {e}", file=sys.stderr)
                 return TemplateNarrator().render(template, ctx)
 
-        return ai_cached_generate(
+        tpl_id = (ctx or {}).get("tpl_id", "")
+        location = (ctx or {}).get("location", "")
+        tod = ((ctx or {}).get("time") or "").lower()
+        time_bucket = {
+            "morning": "am",
+            "afternoon": "pm",
+            "evening": "pm",
+            "night": "night",
+        }.get(tod, (ctx or {}).get("time", ""))
+
+        return ai_cached_generate_v2(
             model,
             style,
             section,
-            prompt,
+            tpl_id,
+            location,
+            time_bucket,
             debug=debug,
-            generator=_call,
+            generator=lambda: _call(prompt, model),
         )

--- a/grimbrain/scripts/campaign_play.py
+++ b/grimbrain/scripts/campaign_play.py
@@ -417,22 +417,38 @@ def travel(
     tpl_ctx = _narration_context(st)
     narrator = _get_narrator_instance()
     style_name = getattr(st, "narrative_style", "classic")
-    start_line = pick_template_line(
+    start_line, start_tpl = pick_template_line(
         style_name, "travel_start", tpl_ctx, seed=_seed_with_offset(base_seed, 0)
     )
     if start_line:
-        print(narrator.render("travel#start", start_line, tpl_ctx))
+        start_ctx = dict(tpl_ctx)
+        start_ctx.update(
+            {
+                "style": style_name,
+                "section": "travel",
+                "tpl_id": start_tpl,
+            }
+        )
+        print(narrator.render("travel#start", start_line, start_ctx))
     if res.get("encounter"):
         winner = res.get("winner", "?")
         outcome = "Victory!" if winner == "A" else "Defeat..."
-        intro_line = pick_template_line(
+        intro_line, intro_tpl = pick_template_line(
             style_name,
             "encounter_intro",
             tpl_ctx,
             seed=_seed_with_offset(base_seed, 1),
         )
         if intro_line:
-            print(narrator.render("travel#encounter_intro", intro_line, tpl_ctx))
+            intro_ctx = dict(tpl_ctx)
+            intro_ctx.update(
+                {
+                    "style": style_name,
+                    "section": "travel",
+                    "tpl_id": intro_tpl,
+                }
+            )
+            print(narrator.render("travel#encounter_intro", intro_line, intro_ctx))
         print(f"Encounter: {res['encounter']} — {outcome}")
         if notes:
             print("\n".join(notes))
@@ -441,23 +457,45 @@ def travel(
         )
         print(f"Party HP: {hp}")
         outcome_key = "encounter_victory" if winner == "A" else "encounter_defeat"
-        outcome_line = pick_template_line(
+        outcome_line, outcome_tpl = pick_template_line(
             style_name,
             outcome_key,
             tpl_ctx,
             seed=_seed_with_offset(base_seed, 2),
         )
         if outcome_line:
-            print(narrator.render(f"travel#{outcome_key}", outcome_line, tpl_ctx))
+            outcome_ctx = dict(tpl_ctx)
+            outcome_ctx.update(
+                {
+                    "style": style_name,
+                    "section": "travel",
+                    "tpl_id": outcome_tpl,
+                }
+            )
+            print(
+                narrator.render(
+                    f"travel#{outcome_key}", outcome_line, outcome_ctx
+                )
+            )
     else:
-        no_encounter_line = pick_template_line(
+        no_encounter_line, no_tpl = pick_template_line(
             style_name,
             "travel_no_encounter",
             tpl_ctx,
             seed=_seed_with_offset(base_seed, 1),
         )
         if no_encounter_line:
-            print(narrator.render("travel#no_encounter", no_encounter_line, tpl_ctx))
+            no_ctx = dict(tpl_ctx)
+            no_ctx.update(
+                {
+                    "style": style_name,
+                    "section": "travel",
+                    "tpl_id": no_tpl,
+                }
+            )
+            print(
+                narrator.render("travel#no_encounter", no_encounter_line, no_ctx)
+            )
 
 
 @app.command()
@@ -525,14 +563,22 @@ def short_rest(
     narrator = _get_narrator_instance()
     tpl_ctx = _narration_context(st)
     style_name = getattr(st, "narrative_style", "classic")
-    rest_line = pick_template_line(
+    rest_line, rest_tpl = pick_template_line(
         style_name,
         "rest_short",
         tpl_ctx,
         seed=_seed_with_offset(_state_seed(st), 0),
     )
     if rest_line:
-        print(narrator.render("rest#short", rest_line, tpl_ctx))
+        rest_ctx = dict(tpl_ctx)
+        rest_ctx.update(
+            {
+                "style": style_name,
+                "section": "rest",
+                "tpl_id": rest_tpl,
+            }
+        )
+        print(narrator.render("rest#short", rest_line, rest_ctx))
     if notes:
         print("\n".join(notes))
 
@@ -555,14 +601,22 @@ def long_rest(ctx: typer.Context = None, load: str = typer.Option(..., "--load")
     narrator = _get_narrator_instance()
     tpl_ctx = _narration_context(st)
     style_name = getattr(st, "narrative_style", "classic")
-    rest_line = pick_template_line(
+    rest_line, rest_tpl = pick_template_line(
         style_name,
         "rest_long",
         tpl_ctx,
         seed=_seed_with_offset(_state_seed(st), 0),
     )
     if rest_line:
-        print(narrator.render("rest#long", rest_line, tpl_ctx))
+        rest_ctx = dict(tpl_ctx)
+        rest_ctx.update(
+            {
+                "style": style_name,
+                "section": "rest",
+                "tpl_id": rest_tpl,
+            }
+        )
+        print(narrator.render("rest#long", rest_line, rest_ctx))
     print("Long rest: party restored to full and conditions cleared.")
 
 

--- a/tests/phase15/test_ai_cache_layer.py
+++ b/tests/phase15/test_ai_cache_layer.py
@@ -2,38 +2,48 @@ import os
 import shutil
 import tempfile
 
-from grimbrain.engine.narrator import ai_cached_generate, _ai_cache_path
+from grimbrain.engine.narrator import (
+    ai_cached_generate_v2,
+    _ai_cache_key_v2,
+    _ai_cache_path_from_key,
+)
 
 
 def test_ai_cache_hit_and_write_visible():
     tmp = tempfile.mkdtemp()
     os.environ["GRIMBRAIN_AI_CACHE_DIR"] = tmp
     try:
-        model, style, section, text = "gpt-test", "classic", "travel", "Hello world"
+        model, style, section = "gpt-test", "classic", "travel"
+        tpl_id, location, time_bucket = "pack:sec:1", "Wilderness", "pm"
 
-        gen1 = lambda prompt, model_name: "FIRST"
-        out1 = ai_cached_generate(
+        gen1 = lambda: "FIRST"
+        out1 = ai_cached_generate_v2(
             model,
             style,
             section,
-            text,
+            tpl_id,
+            location,
+            time_bucket,
             debug=True,
             generator=gen1,
         )
         assert out1 == "FIRST"
 
-        gen2 = lambda prompt, model_name: "SECOND"
-        out2 = ai_cached_generate(
+        gen2 = lambda: "SECOND"
+        out2 = ai_cached_generate_v2(
             model,
             style,
             section,
-            text,
+            tpl_id,
+            location,
+            time_bucket,
             debug=True,
             generator=gen2,
         )
         assert out2 == "FIRST"
 
-        assert _ai_cache_path(model, style, section, text).exists()
+        key = _ai_cache_key_v2(model, style, section, tpl_id, location, time_bucket)
+        assert _ai_cache_path_from_key(key).exists()
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
         os.environ.pop("GRIMBRAIN_AI_CACHE_DIR", None)

--- a/tests/phase15/test_narrative_packs.py
+++ b/tests/phase15/test_narrative_packs.py
@@ -11,7 +11,8 @@ def test_pick_template_line_deterministic():
         "time": "morning",
         "location": "Wilderness",
     }
-    a = pick_template_line("classic", "travel_start", ctx, seed=123)
-    b = pick_template_line("classic", "travel_start", ctx, seed=123)
-    c = pick_template_line("classic", "travel_start", ctx, seed=124)
-    assert a == b and a != c
+    a_text, a_tpl = pick_template_line("classic", "travel_start", ctx, seed=123)
+    b_text, b_tpl = pick_template_line("classic", "travel_start", ctx, seed=123)
+    c_text, c_tpl = pick_template_line("classic", "travel_start", ctx, seed=124)
+    assert a_text == b_text and a_tpl == b_tpl
+    assert a_text != c_text or a_tpl != c_tpl

--- a/tests/phase16/test_ai_cache_v2.py
+++ b/tests/phase16/test_ai_cache_v2.py
@@ -1,0 +1,47 @@
+import os
+import shutil
+import tempfile
+
+from grimbrain.engine.narrator import ai_cached_generate_v2, _ai_index_load
+
+
+def test_v2_hits_with_same_context():
+    tmp = tempfile.mkdtemp()
+    os.environ["GRIMBRAIN_AI_CACHE_DIR"] = tmp
+    try:
+        model, style, section = "openai:gpt-4o-mini", "grim", "travel"
+        tpl_id, location, tb = "classic:travel_start:1", "Wilderness", "pm"
+        calls = {"n": 0}
+
+        def gen():
+            calls["n"] += 1
+            return f"OUT-{calls['n']}"
+
+        out1 = ai_cached_generate_v2(
+            model,
+            style,
+            section,
+            tpl_id,
+            location,
+            tb,
+            debug=False,
+            generator=gen,
+        )
+        out2 = ai_cached_generate_v2(
+            model,
+            style,
+            section,
+            tpl_id,
+            location,
+            tb,
+            debug=False,
+            generator=gen,
+        )
+        assert out1 == out2 == "OUT-1"
+        idx = _ai_index_load()
+        assert len(idx) == 1
+        hits = list(idx.values())[0]["hits"]
+        assert hits >= 2
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+        os.environ.pop("GRIMBRAIN_AI_CACHE_DIR", None)


### PR DESCRIPTION
## Summary
- replace the narration cache with structured keys that track template id, location, and time buckets while persisting an index with hit counts and LRU trimming
- update the AI narrator and campaign script to pass template ids and contextual metadata so cache hits become deterministic and debug logging exposes the new key
- adjust tests for the new picker return value and add coverage for the v2 cache index behaviour

## Testing
- PYTEST_ADDOPTS=--no-cov pytest tests/phase15/test_ai_cache_layer.py tests/phase15/test_narrative_packs.py tests/phase16/test_ai_cache_v2.py


------
https://chatgpt.com/codex/tasks/task_e_68d6ebadc0f48327a271805af7ca1a3f