### PR TITLE
Implement deterministic AI cache and environment loader

### DIFF
--- a/grimbrain/ai/__init__.py
+++ b/grimbrain/ai/__init__.py
@@ -1,5 +1,5 @@
 """AI cache utilities."""
 
-from .ai_cache import CacheInputs, call_with_cache, make_cache_key
+from .ai_cache import CacheInputs, call_with_cache, make_cache_key, make_key
 
-__all__ = ["CacheInputs", "call_with_cache", "make_cache_key"]
+__all__ = ["CacheInputs", "call_with_cache", "make_key", "make_cache_key"]

--- a/grimbrain/cli.py
+++ b/grimbrain/cli.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from grimbrain.config_env import load_env as _gb_load_env  # noqa: E402
+
+_gb_load_env()
+
 from functools import partial
 from pathlib import Path
 import sys

--- a/grimbrain/config_env.py
+++ b/grimbrain/config_env.py
@@ -1,0 +1,39 @@
+"""Helpers for loading project environment configuration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def load_env() -> None:
+    """Load environment variables from .env files without overriding process env."""
+
+    try:
+        from dotenv import find_dotenv, load_dotenv
+    except Exception:  # pragma: no cover - optional dependency or import error
+        return
+
+    cwd = Path.cwd()
+
+    base = find_dotenv(".env", usecwd=True)
+    if base:
+        load_dotenv(base, override=False)
+
+    local_file = cwd / ".env.local"
+    if local_file.exists():
+        load_dotenv(local_file, override=False)
+
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        test_file = cwd / ".env.test"
+        if test_file.exists():
+            load_dotenv(test_file, override=False)
+
+    cache_dir = os.getenv("GRIMBRAIN_AI_CACHE_DIR")
+    if cache_dir:
+        normalized = Path(cache_dir).expanduser()
+        try:
+            normalized = normalized.resolve()
+        except OSError:
+            pass
+        os.environ["GRIMBRAIN_AI_CACHE_DIR"] = str(normalized)

--- a/grimbrain/play_cli.py
+++ b/grimbrain/play_cli.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from grimbrain.config_env import load_env as _gb_load_env  # noqa: E402
+
+_gb_load_env()
+
 import argparse
 import json
 import os

--- a/grimbrain/scripts/campaign_play.py
+++ b/grimbrain/scripts/campaign_play.py
@@ -7,6 +7,10 @@ from typing import Any
 if __package__ is None or __package__ == "":
     sys.path.append(str(Path(__file__).resolve().parents[2]))
 
+from grimbrain.config_env import load_env as _gb_load_env  # noqa: E402
+
+_gb_load_env()
+
 import typer
 from typer.models import ArgumentInfo, OptionInfo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "pyyaml>=6.0.2",
   "jsonschema>=4.23",
   "reportlab>=4.0",
+  "python-dotenv>=1.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytest
 pytest-cov
 jsonschema
 reportlab>=4.0
+python-dotenv

--- a/tests/config/test_env_loading.py
+++ b/tests/config/test_env_loading.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+from grimbrain.config_env import load_env
+
+
+def test_env_loads_dotenv(tmp_path, monkeypatch):
+    (tmp_path / ".env").write_text("FOO=bar\nOPENAI_API_KEY=from_env_file\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENAI_API_KEY", "from_process")
+    monkeypatch.delenv("FOO", raising=False)
+
+    load_env()
+
+    assert os.getenv("FOO") == "bar"
+    assert os.getenv("OPENAI_API_KEY") == "from_process"
+
+
+def test_ai_cache_dir_from_env(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("GRIMBRAIN_AI_CACHE_DIR=./.grimbrain_cache\n", encoding="utf-8")
+
+    load_env()
+
+    cache_dir = os.getenv("GRIMBRAIN_AI_CACHE_DIR")
+    assert cache_dir
+    assert Path(cache_dir) == (tmp_path / ".grimbrain_cache").resolve()


### PR DESCRIPTION
## Summary
- add a shared load_env helper that loads .env/.env.local/.env.test without overriding real environment variables and normalises the cache directory
- wire environment loading into the command line entrypoints so configuration is available immediately
- harden the AI cache with deterministic keys, stale-index repairs, atomic writes, input-aware callables, and refreshed tests
- record python-dotenv as a dependency and add coverage for the new behaviour

## Testing
- pytest tests/config/test_env_loading.py -q --no-cov
- pytest tests/ai/test_ai_cache.py -q --no-cov

------
https://chatgpt.com/codex/tasks/task_e_68dac6f1ebac83278a1d656c218d67b1