### PR TITLE
Refactor campaign state I/O and update CLI tests

### DIFF
--- a/grimbrain/io/__init__.py
+++ b/grimbrain/io/__init__.py
@@ -1,0 +1,3 @@
+from .campaign_io import load_campaign, save_campaign, yaml
+
+__all__ = ["load_campaign", "save_campaign", "yaml"]

--- a/grimbrain/io/campaign_io.py
+++ b/grimbrain/io/campaign_io.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - PyYAML is optional
+    yaml = None  # type: ignore
+
+from grimbrain.models.campaign import CampaignState
+
+
+def _prune_empty_lists(value: Any) -> Any:
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, inner in value.items():
+            cleaned = _prune_empty_lists(inner)
+            if isinstance(cleaned, list) and len(cleaned) == 0:
+                continue
+            result[key] = cleaned
+        return result
+    if isinstance(value, list):
+        cleaned_items = [_prune_empty_lists(item) for item in value]
+        return [item for item in cleaned_items if not (isinstance(item, list) and len(item) == 0)]
+    return value
+
+
+def _load_payload(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+    if suffix in {".yaml", ".yml"}:
+        if yaml is None:
+            raise RuntimeError("PyYAML is required to read YAML")
+        data = yaml.safe_load(text)
+    else:
+        data = json.loads(text)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError("Campaign file must contain an object at the top level")
+    return dict(data)
+
+
+def load_campaign(path: str | Path) -> CampaignState:
+    """Load a campaign document from disk as a CampaignState."""
+
+    p = Path(path)
+    data = _load_payload(p)
+    return CampaignState.from_dict(data)
+
+
+def save_campaign(state: CampaignState, path: str | Path, fmt: str | None = None) -> Path:
+    """Persist a CampaignState to disk in JSON (default) or YAML."""
+
+    if not isinstance(state, CampaignState):
+        raise TypeError("save_campaign expects a CampaignState instance")
+
+    p = Path(path)
+    chosen = (fmt or "").lower() or None
+    if chosen not in {None, "json", "yaml", "yml"}:
+        raise ValueError("fmt must be json or yaml")
+    if chosen is None:
+        suffix = p.suffix.lower()
+        if suffix in {".yaml", ".yml"}:
+            chosen = "yaml"
+        else:
+            chosen = "json"
+    payload = state.to_dict()
+    if chosen == "yaml":
+        if yaml is None:
+            raise RuntimeError("PyYAML is required to write YAML")
+        cleaned = _prune_empty_lists(payload)
+        p.write_text(yaml.safe_dump(cleaned, sort_keys=False), encoding="utf-8")
+    else:
+        p.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return p
+
+
+__all__ = ["load_campaign", "save_campaign", "yaml"]

--- a/tests/cli/test_campaign_io.py
+++ b/tests/cli/test_campaign_io.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import json
 
 from grimbrain.models.campaign import CampaignState
-from grimbrain.scripts.campaign_play import load_campaign, save_campaign, yaml
+from grimbrain.io.campaign_io import load_campaign, save_campaign, yaml
 
 
 def test_load_json_roundtrip(tmp_path):

--- a/tests/cli/test_campaign_play_sample_json.py
+++ b/tests/cli/test_campaign_play_sample_json.py
@@ -26,7 +26,7 @@ def test_sample_json_then_status(tmp_path):
     assert result.exit_code == 0
     assert demo.exists()
     data = json.loads(demo.read_text(encoding="utf-8"))
-    assert data["clock"]["day"] == 1
+    assert data["day"] == 1
     status = runner.invoke(cp.app, ["status", "--load", str(demo)])
     assert status.exit_code == 0
     output_text = status.stdout or status.output

--- a/tests/models/test_campaign_state_dict_roundtrip.py
+++ b/tests/models/test_campaign_state_dict_roundtrip.py
@@ -1,4 +1,4 @@
-from grimbrain.models.campaign import CampaignState, PartyMemberRef
+from grimbrain.models.campaign import CampaignState
 
 
 def test_campaignstate_roundtrip_basic():
@@ -9,14 +9,19 @@ def test_campaignstate_roundtrip_basic():
         location="Wilderness",
         gold=7,
         inventory={"rations": 3},
-        party=[PartyMemberRef(id="Aria", name="Aria", max_hp=11, ac=12, pb=2)],
+        party=[{"id": "Aria", "name": "Aria", "hp_max": 11, "hp_current": 11}],
+        style="classic",
+        flags={"mode": "solo"},
+        journal=["entry"],
     )
     data = st.to_dict()
     st2 = CampaignState.from_dict(data)
     assert st2.day == 2
     assert st2.time_of_day == "afternoon"
-    assert st2.party[0].name == "Aria"
-    assert st2.current_hp["Aria"] == 11
+    assert st2.party[0]["name"] == "Aria"
+    assert st2.party[0]["hp_current"] == 11
+    assert st2.flags["mode"] == "solo"
+    assert st2.journal == ["entry"]
 
 
 def test_from_dict_legacy_shapes():
@@ -37,11 +42,11 @@ def test_from_dict_legacy_shapes():
             ],
         },
         "inventory": {"rations": 2},
+        "state": {"current_hp": {"PC1": 8}},
     }
     st = CampaignState.from_dict(legacy)
     assert st.day == 1 and st.time_of_day == "evening"
     assert st.location == "Village Gate"
-    assert st.region == "Greenfields"
     assert st.gold == 12
-    assert st.party[0].name == "Scout"
-    assert st.current_hp["PC1"] == 8
+    assert st.party[0]["name"] == "Scout"
+    assert st.party[0]["hp_current"] == 8

--- a/tests/models/test_campaign_state_roundtrip.py
+++ b/tests/models/test_campaign_state_roundtrip.py
@@ -1,0 +1,25 @@
+from grimbrain.models.campaign import CampaignState
+
+
+def test_campaign_state_roundtrip_simple():
+    st = CampaignState(
+        seed=123,
+        day=3,
+        time_of_day="dusk",
+        location="Greenfields: Village Gate",
+        gold=50,
+        inventory={"rations": 5},
+        party=[{"id": "PC1", "name": "Rin", "hp_max": 10, "hp_current": 8}],
+        style="grim",
+        flags={"blessed": True},
+        journal=[{"day": 3, "note": "Arrived"}],
+    )
+    data = st.to_dict()
+    st2 = CampaignState.from_dict(data)
+    assert isinstance(st2, CampaignState)
+    assert st2.day == st.day
+    assert st2.time_of_day == st.time_of_day
+    assert st2.party[0]["id"] == st.party[0]["id"]
+    assert st2.party[0]["hp_current"] == 8
+    assert st2.flags == {"blessed": True}
+    assert st2.journal == [{"day": 3, "note": "Arrived"}]


### PR DESCRIPTION
## Summary
- replace the CampaignState helper with a dataclass that normalizes legacy and flat payloads and emits a flat dict for serialization
- add dedicated campaign I/O helpers that read/write JSON or YAML (with empty-list pruning) and wire the CLI to them
- refresh the CLI sample command and tests to operate on CampaignState objects and verify round-trips

## Testing
- pytest --no-cov tests/models/test_campaign_state_roundtrip.py -q
- pytest --no-cov tests/cli/test_campaign_io.py -q
- pytest --no-cov tests/cli/test_campaign_play_sample_json.py -q
- pytest --no-cov tests/models/test_campaign_state_dict_roundtrip.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dc649e74448327be5dd5dcfce17a21