### PR TITLE
Refactor campaign I/O around dictionary campaign state

### DIFF
--- a/grimbrain/io/campaign_io.py
+++ b/grimbrain/io/campaign_io.py
@@ -1,38 +1,22 @@
 from __future__ import annotations
 
 import json
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 try:  # pragma: no cover - optional dependency
     import yaml  # type: ignore
 except Exception:  # pragma: no cover - PyYAML is optional
     yaml = None  # type: ignore
 
-from grimbrain.models.campaign import CampaignState
 
-
-def _prune_empty_lists(value: Any) -> Any:
-    if isinstance(value, dict):
-        result: dict[str, Any] = {}
-        for key, inner in value.items():
-            cleaned = _prune_empty_lists(inner)
-            if isinstance(cleaned, list) and len(cleaned) == 0:
-                continue
-            result[key] = cleaned
-        return result
-    if isinstance(value, list):
-        cleaned_items = [_prune_empty_lists(item) for item in value]
-        return [item for item in cleaned_items if not (isinstance(item, list) and len(item) == 0)]
-    return value
-
-
-def _load_payload(path: Path) -> dict[str, Any]:
+def _read_payload(path: Path) -> Dict[str, Any]:
     text = path.read_text(encoding="utf-8")
     suffix = path.suffix.lower()
     if suffix in {".yaml", ".yml"}:
         if yaml is None:
-            raise RuntimeError("PyYAML is required to read YAML")
+            raise RuntimeError("PyYAML is required for YAML support")
         data = yaml.safe_load(text)
     else:
         data = json.loads(text)
@@ -43,19 +27,206 @@ def _load_payload(path: Path) -> dict[str, Any]:
     return dict(data)
 
 
-def load_campaign(path: str | Path) -> CampaignState:
-    """Load a campaign document from disk as a CampaignState."""
+def _coerce_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize_inventory(raw: Any) -> Dict[str, Any]:
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        result: Dict[str, Any] = {}
+        for key, value in raw.items():
+            name = str(key)
+            try:
+                result[name] = int(value)
+            except (TypeError, ValueError):
+                result[name] = value
+        return result
+    if isinstance(raw, list):
+        result: Dict[str, int] = {}
+        for entry in raw:
+            name = str(entry)
+            result[name] = result.get(name, 0) + 1
+        return result
+    return {}
+
+
+def _normalize_member(raw: Any, idx: int, hp_overrides: Dict[str, Any]) -> Dict[str, Any]:
+    if isinstance(raw, dict):
+        payload = dict(raw)
+    else:
+        payload = {"name": str(raw)}
+    hp_info = payload.pop("hp", {}) or {}
+    member_id = str(payload.get("id") or payload.get("name") or f"PC{idx}")
+    name = str(payload.get("name") or member_id)
+    hp_max_raw = payload.pop("hp_max", payload.pop("max_hp", hp_info.get("max")))
+    hp_max = _coerce_int(hp_max_raw, default=12)
+    hp_current_raw = payload.pop(
+        "hp_current",
+        payload.pop("current_hp", hp_info.get("current", hp_overrides.get(member_id))),
+    )
+    hp_current = _coerce_int(hp_current_raw, default=hp_max)
+    member: Dict[str, Any] = {
+        "id": member_id,
+        "name": name,
+        "hp_max": hp_max,
+        "hp_current": max(0, min(hp_max, hp_current)),
+    }
+    for key in list(payload.keys()):
+        value = payload[key]
+        member[key] = value
+    return member
+
+
+def _location_string(data: Dict[str, Any]) -> str:
+    location_value = data.get("location")
+    if isinstance(location_value, dict):
+        region = location_value.get("region")
+        place = location_value.get("place") or location_value.get("location")
+        name = location_value.get("name")
+        if region and place:
+            return f"{region}: {place}"
+        return str(place or region or name or "Wilderness")
+    if location_value:
+        return str(location_value)
+    loc_info = data.get("location_info")
+    if isinstance(loc_info, dict):
+        return str(
+            loc_info.get("name")
+            or loc_info.get("place")
+            or loc_info.get("region")
+            or "Wilderness"
+        )
+    return "Wilderness"
+
+
+def load_campaign(path: str | Path) -> Dict[str, Any]:
+    """Load a campaign document and normalize it to a plain dictionary."""
 
     p = Path(path)
-    data = _load_payload(p)
-    return CampaignState.from_dict(data)
+    payload = _read_payload(p)
+    state: Dict[str, Any] = dict(payload)
+
+    clock = payload.get("clock") if isinstance(payload.get("clock"), dict) else {}
+    state["seed"] = _coerce_int(payload.get("seed"), default=0)
+    state["day"] = _coerce_int(payload.get("day", clock.get("day", 1)), default=1)
+    state["time_of_day"] = str(payload.get("time_of_day", clock.get("time", "morning")))
+    state["location"] = _location_string(payload)
+
+    party_block = payload.get("party")
+    members_source = None
+    gold_value = payload.get("gold")
+    if isinstance(party_block, dict):
+        members_source = party_block.get("members")
+        if gold_value is None and "gold" in party_block:
+            gold_value = party_block.get("gold")
+    elif isinstance(party_block, list):
+        members_source = party_block
+
+    party_info_block = payload.get("party_info")
+    if members_source is None and isinstance(party_info_block, dict):
+        members_source = party_info_block.get("members")
+        if gold_value is None and "gold" in party_info_block:
+            gold_value = party_info_block.get("gold")
+
+    if members_source is None:
+        members_source = []
+
+    state["gold"] = _coerce_int(gold_value, default=0)
+    state["inventory"] = _normalize_inventory(payload.get("inventory"))
+
+    current_hp_source: Dict[str, Any] = {}
+    if isinstance(payload.get("state"), dict):
+        state_block = payload["state"]
+        if isinstance(state_block.get("current_hp"), dict):
+            current_hp_source.update({str(k): v for k, v in state_block["current_hp"].items()})
+    if isinstance(payload.get("current_hp"), dict):
+        current_hp_source.update({str(k): v for k, v in payload["current_hp"].items()})
+
+    members: list[Dict[str, Any]] = []
+    current_hp: Dict[str, int] = {}
+    for idx, entry in enumerate(members_source or [], start=1):
+        member = _normalize_member(entry, idx, current_hp_source)
+        members.append(member)
+        current_hp[member["id"]] = member.get("hp_current", member.get("hp_max", 0))
+    state["party"] = members
+    hp_map: Dict[str, int] = {}
+    for key, value in (current_hp_source or {}).items():
+        hp_map[str(key)] = _coerce_int(value, default=0)
+    for key, value in current_hp.items():
+        hp_map[key] = _coerce_int(value, default=value)
+    state["current_hp"] = hp_map
+
+    style_value = payload.get("style") or payload.get("narrative_style") or "classic"
+    state["style"] = str(style_value)
+
+    flags_raw = payload.get("flags")
+    state["flags"] = dict(flags_raw) if isinstance(flags_raw, dict) else {}
+
+    journal_raw = payload.get("journal")
+    if isinstance(journal_raw, list):
+        state["journal"] = list(journal_raw)
+    elif journal_raw is None:
+        state["journal"] = []
+    else:
+        state["journal"] = [journal_raw]
+
+    quest_log_raw = payload.get("quest_log")
+    if isinstance(quest_log_raw, list):
+        state["quest_log"] = list(quest_log_raw)
+    else:
+        state["quest_log"] = []
+
+    encounter_info = {}
+    if isinstance(payload.get("state"), dict) and isinstance(payload["state"].get("encounter"), dict):
+        encounter_info = payload["state"]["encounter"]
+    state["encounter_chance"] = _coerce_int(
+        payload.get("encounter_chance", encounter_info.get("chance", 30)),
+        default=30,
+    )
+    state["encounter_clock"] = _coerce_int(
+        payload.get("encounter_clock", encounter_info.get("clock", 0)),
+        default=0,
+    )
+    state["encounter_clock_step"] = _coerce_int(
+        payload.get("encounter_clock_step", encounter_info.get("step", 10)),
+        default=10,
+    )
+
+    rest_info = {}
+    if isinstance(payload.get("state"), dict) and isinstance(payload["state"].get("rest"), dict):
+        rest_info = payload["state"]["rest"]
+    state["short_rest_hours"] = _coerce_int(
+        payload.get("short_rest_hours", rest_info.get("short_hours", 4)),
+        default=4,
+    )
+    state["long_rest_to_morning"] = bool(
+        payload.get("long_rest_to_morning", rest_info.get("long_to_morning", True))
+    )
+    state["last_long_rest_day"] = _coerce_int(
+        payload.get("last_long_rest_day", payload.get("state", {}).get("last_long_rest_day", 0)),
+        default=0,
+    )
+    state["light_level"] = str(
+        payload.get("light_level", payload.get("state", {}).get("light", "normal"))
+    )
+    state["narrative_style"] = str(style_value)
+
+    if not state.get("current_hp"):
+        state["current_hp"] = {m["id"]: m.get("hp_current", m.get("hp_max", 0)) for m in members}
+
+    return state
 
 
-def save_campaign(state: CampaignState, path: str | Path, fmt: str | None = None) -> Path:
-    """Persist a CampaignState to disk in JSON (default) or YAML."""
+def save_campaign(data: Dict[str, Any], path: str | Path, fmt: str | None = None) -> Path:
+    """Save a normalized campaign dictionary to disk."""
 
-    if not isinstance(state, CampaignState):
-        raise TypeError("save_campaign expects a CampaignState instance")
+    if not isinstance(data, dict):
+        raise TypeError("save_campaign expects a dictionary")
 
     p = Path(path)
     chosen = (fmt or "").lower() or None
@@ -67,12 +238,46 @@ def save_campaign(state: CampaignState, path: str | Path, fmt: str | None = None
             chosen = "yaml"
         else:
             chosen = "json"
-    payload = state.to_dict()
-    if chosen == "yaml":
+
+    payload = dict(data)
+    raw_party = payload.get("party")
+    if isinstance(raw_party, list):
+        party_list = []
+        for member in raw_party:
+            if isinstance(member, dict):
+                party_list.append(dict(member))
+            elif is_dataclass(member):
+                party_list.append(asdict(member))
+            else:
+                party_list.append({"name": str(member)})
+    else:
+        party_list = []
+    payload["party"] = party_list
+    style_value = payload.get("style") or payload.get("narrative_style") or "classic"
+    payload["style"] = str(style_value)
+    payload["narrative_style"] = str(style_value)
+    payload.setdefault("inventory", {})
+    payload.setdefault("journal", [])
+    payload.setdefault("flags", {})
+
+    current_hp_map = payload.get("current_hp")
+    if not isinstance(current_hp_map, dict):
+        current_hp_map = {}
+    for member in party_list:
+        if isinstance(member, dict):
+            mid = member.get("id")
+            if not mid:
+                continue
+            hp_value = member.get("hp_current", member.get("hp", member.get("hp_max", 0)))
+            current_hp_map.setdefault(str(mid), _coerce_int(hp_value, default=0))
+    payload["current_hp"] = {str(k): _coerce_int(v, default=0) for k, v in current_hp_map.items()}
+
+    if chosen in {"yaml", "yml"}:
         if yaml is None:
-            raise RuntimeError("PyYAML is required to write YAML")
-        cleaned = _prune_empty_lists(payload)
-        p.write_text(yaml.safe_dump(cleaned, sort_keys=False), encoding="utf-8")
+            raise RuntimeError("PyYAML is required for YAML support")
+        text = yaml.safe_dump(payload, sort_keys=False)
+        text = text.replace(":\n  []", ": []").replace(":\n  {}", ": {}")
+        p.write_text(text, encoding="utf-8")
     else:
         p.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     return p

--- a/tests/cli/test_campaign_io.py
+++ b/tests/cli/test_campaign_io.py
@@ -1,35 +1,92 @@
-from pathlib import Path
 import json
+from pathlib import Path
 
-from grimbrain.models.campaign import CampaignState
+import pytest
+
 from grimbrain.io.campaign_io import load_campaign, save_campaign, yaml
 
 
-def test_load_json_roundtrip(tmp_path):
-    p = tmp_path / "c.json"
-    obj = {"clock": {"day": 2, "time": "noon"}}
-    p.write_text(json.dumps(obj), encoding="utf-8")
-    loaded = load_campaign(p)
-    assert isinstance(loaded, CampaignState)
-    assert loaded.day == 2
-    assert loaded.time_of_day == "noon"
+def test_load_json_normalizes_legacy(tmp_path):
+    p = tmp_path / "legacy.json"
+    payload = {
+        "seed": 5,
+        "clock": {"day": 3, "time": "evening"},
+        "location": {"region": "Greenfields", "place": "Village Gate"},
+        "party": {
+            "gold": 12,
+            "members": [
+                {
+                    "id": "PC1",
+                    "name": "Scout",
+                    "hp": {"max": 10, "current": 7},
+                    "ac": 13,
+                }
+            ],
+        },
+        "inventory": ["torch", "torch", "rations"],
+        "state": {"current_hp": {"PC1": 7}},
+    }
+    p.write_text(json.dumps(payload), encoding="utf-8")
+
+    state = load_campaign(p)
+    assert state["day"] == 3
+    assert state["time_of_day"] == "evening"
+    assert state["location"] == "Greenfields: Village Gate"
+    assert state["gold"] == 12
+    assert state["inventory"] == {"torch": 2, "rations": 1}
+    assert state["party"][0]["hp_current"] == 7
+    assert state["current_hp"]["PC1"] == 7
 
 
-def test_save_json_default(tmp_path):
-    p = tmp_path / "c.json"
-    state = CampaignState(seed=99, day=4, time_of_day="evening", location="Keep")
-    save_campaign(state, p)
-    payload = json.loads(p.read_text())
-    assert payload["day"] == 4
-    assert payload["time_of_day"] == "evening"
+def test_save_and_reload_roundtrip(tmp_path):
+    p = tmp_path / "campaign.json"
+    data = {
+        "seed": 9,
+        "day": 2,
+        "time_of_day": "afternoon",
+        "location": "Keep",
+        "gold": 5,
+        "inventory": {"rations": 3},
+        "party": [
+            {
+                "id": "PC1",
+                "name": "Ranger",
+                "hp_max": 14,
+                "hp_current": 11,
+                "dex_mod": 3,
+            }
+        ],
+        "style": "classic",
+        "flags": {"mode": "solo"},
+        "journal": ["entry"],
+    }
+    save_campaign(data, p)
+
+    reloaded = load_campaign(p)
+    assert reloaded["seed"] == 9
+    assert reloaded["day"] == 2
+    assert reloaded["time_of_day"] == "afternoon"
+    assert reloaded["party"][0]["hp_current"] == 11
+    assert reloaded["current_hp"]["PC1"] == 11
+    assert reloaded["flags"]["mode"] == "solo"
+    assert reloaded["journal"] == ["entry"]
 
 
 def test_yaml_optional(tmp_path):
-    p = tmp_path / "c.yaml"
+    p = tmp_path / "campaign.yaml"
     if yaml is None:
-        return
-    state = CampaignState(seed=5, gold=12, party=[])
-    save_campaign(state, p, fmt="yaml")
-    loaded = load_campaign(p)
-    assert isinstance(loaded, CampaignState)
-    assert loaded.gold == 12
+        pytest.skip("PyYAML not installed")
+
+    data = {
+        "seed": 2,
+        "day": 1,
+        "time_of_day": "morning",
+        "location": "Outpost",
+        "party": [],
+        "inventory": {},
+    }
+    save_campaign(data, p, fmt="yaml")
+
+    state = load_campaign(p)
+    assert state["location"] == "Outpost"
+    assert state["day"] == 1

--- a/tests/cli/test_campaign_play_commands.py
+++ b/tests/cli/test_campaign_play_commands.py
@@ -1,0 +1,128 @@
+import pytest
+
+try:  # Typer >=0.9
+    from typer.testing import CliRunner  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    from click.testing import CliRunner  # type: ignore
+
+from grimbrain.io.campaign_io import save_campaign
+from grimbrain.scripts import campaign_play as cp
+
+
+runner = CliRunner()
+
+
+def _require_real_typer() -> None:
+    if not hasattr(cp.app, "main"):
+        pytest.skip("Typer runner not available")
+
+
+def _baseline_state() -> dict:
+    return {
+        "seed": 42,
+        "day": 1,
+        "time_of_day": "morning",
+        "location": "Village",
+        "gold": 0,
+        "inventory": {"rations": 2},
+        "party": [
+            {
+                "id": "PC1",
+                "name": "Hero",
+                "str_mod": 1,
+                "dex_mod": 1,
+                "con_mod": 1,
+                "int_mod": 0,
+                "wis_mod": 0,
+                "cha_mod": 0,
+                "ac": 13,
+                "pb": 2,
+                "speed": 30,
+                "hp_max": 12,
+                "hp_current": 12,
+            }
+        ],
+        "current_hp": {"PC1": 12},
+        "style": "classic",
+        "narrative_style": "classic",
+        "flags": {},
+        "journal": [],
+        "encounter_chance": 20,
+        "encounter_clock": 0,
+        "encounter_clock_step": 10,
+        "short_rest_hours": 4,
+        "long_rest_to_morning": True,
+    }
+
+
+def test_status_command_outputs(tmp_path):
+    _require_real_typer()
+    path = tmp_path / "state.json"
+    save_campaign(_baseline_state(), path)
+
+    result = runner.invoke(cp.app, ["status", "--load", str(path)])
+    assert result.exit_code == 0
+    text = result.stdout or result.output
+    assert "Day" in text
+    assert "Party" in text
+
+
+def test_short_rest_updates_hp(tmp_path):
+    _require_real_typer()
+    path = tmp_path / "state.json"
+    state = _baseline_state()
+    state["party"][0]["hp_current"] = 5
+    state["current_hp"]["PC1"] = 5
+    save_campaign(state, path)
+
+    result = runner.invoke(cp.app, ["short_rest", "--load", str(path), "--seed", "1"])
+    assert result.exit_code == 0
+
+    reloaded = cp.load_campaign(path)
+    assert reloaded["current_hp"]["PC1"] >= 5
+    assert reloaded["current_hp"]["PC1"] <= 12
+
+
+def test_long_rest_sets_hp_to_max(tmp_path):
+    _require_real_typer()
+    path = tmp_path / "state.json"
+    state = _baseline_state()
+    state["party"][0]["hp_current"] = 4
+    state["current_hp"]["PC1"] = 4
+    save_campaign(state, path)
+
+    result = runner.invoke(cp.app, ["long_rest", "--load", str(path)])
+    assert result.exit_code == 0
+
+    reloaded = cp.load_campaign(path)
+    assert reloaded["current_hp"]["PC1"] == reloaded["party"][0]["hp_max"]
+
+
+def test_travel_advances_time(tmp_path, monkeypatch):
+    _require_real_typer()
+    path = tmp_path / "state.json"
+    state = _baseline_state()
+    save_campaign(state, path)
+
+    def fake_run_encounter(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr(cp, "run_encounter", fake_run_encounter)
+
+    result = runner.invoke(
+        cp.app,
+        [
+            "travel",
+            "--load",
+            str(path),
+            "--seed",
+            "123",
+            "--hours",
+            "4",
+        ],
+    )
+    assert result.exit_code == 0
+
+    reloaded = cp.load_campaign(path)
+    assert reloaded["time_of_day"] in {"afternoon", "evening", "night", "morning"}
+    assert reloaded["day"] >= 1

--- a/tests/cli/test_campaign_play_sample.py
+++ b/tests/cli/test_campaign_play_sample.py
@@ -87,19 +87,19 @@ def test_sample_switches_and_parse(tmp_path):
     assert data["style"] == "heroic"
     assert data["clock"]["day"] == 3
     assert data["clock"]["time"] == "evening"
-    assert data["location"]["region"] == "Northreach"
-    assert data["location"]["place"] == "Harbor"
-    assert data["party"]["gold"] == 25
+    assert data["location"] == "Northreach: Harbor"
     inv = data["inventory"]
     assert inv["rations"] == 5
     assert inv["torches"] == 1
     assert inv["potion"] == 2
     assert inv["rope"] == 1
-    members = data["party"]["members"]
+    members = data["party"]
     assert members[0]["name"] == "Anya"
-    assert members[0]["hp"]["current"] == 6
+    assert members[0]["hp_current"] == 6
     assert members[1]["name"] == "Borin"
-    assert members[1]["hp"]["max"] == 12
+    assert members[1]["hp_max"] == 12
+    assert data["party_info"]["gold"] == 25
+    assert len(data["party_info"]["members"]) == 2
 
 
 def test_sample_no_yaml(tmp_path, monkeypatch):

--- a/tests/cli/test_campaign_play_sample_json.py
+++ b/tests/cli/test_campaign_play_sample_json.py
@@ -7,7 +7,6 @@ try:  # Typer >=0.9
 except ModuleNotFoundError:  # pragma: no cover - compatibility for older Typer
     from click.testing import CliRunner  # type: ignore
 
-from grimbrain.models.campaign import CampaignState
 from grimbrain.scripts import campaign_play as cp
 
 
@@ -27,10 +26,14 @@ def test_sample_json_then_status(tmp_path):
     assert demo.exists()
     data = json.loads(demo.read_text(encoding="utf-8"))
     assert data["day"] == 1
+    assert data["party"]
+
     status = runner.invoke(cp.app, ["status", "--load", str(demo)])
     assert status.exit_code == 0
     output_text = status.stdout or status.output
     assert "day" in output_text.lower() or "location" in output_text.lower()
+
     state = cp.load_campaign(demo)
-    assert isinstance(state, CampaignState)
-    assert state.day >= 1
+    assert isinstance(state, dict)
+    assert state["day"] >= 1
+    assert "party" in state and isinstance(state["party"], list)


### PR DESCRIPTION
## Summary
- rewrite grimbrain.io.campaign_io to normalize legacy and new campaign shapes into a single dictionary representation and emit JSON/YAML safely
- adjust scripts/campaign_play helpers and sample generator to operate on normalized campaign dictionaries when loading and saving state
- refresh CLI tests and add coverage for status/rest/travel commands alongside new I/O expectations

## Testing
- PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/cli/test_campaign_io.py tests/cli/test_campaign_play_sample.py tests/cli/test_campaign_play_sample_json.py tests/cli/test_campaign_play_commands.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd2cb30a288327923407dc405f900b