### PR TITLE
Fix HP field compatibility in campaign I/O

### DIFF
--- a/grimbrain/models/campaign.py
+++ b/grimbrain/models/campaign.py
@@ -325,30 +325,30 @@ class CampaignState:
         for entry in party_entries:
             member = dict(entry)
             hp_blob = member.pop("hp", None)
-            hp_max = member.pop("hp_max", member.pop("max_hp", None))
-            hp_current = member.pop("hp_current", member.pop("current_hp", None))
+            max_hp = member.pop("max_hp", member.pop("hp_max", None))
+            current_hp = member.pop("current_hp", member.pop("hp_current", None))
             if isinstance(hp_blob, dict):
-                hp_max = hp_blob.get("max", hp_max)
-                hp_current = hp_blob.get("current", hp_current)
+                max_hp = hp_blob.get("max", max_hp)
+                current_hp = hp_blob.get("current", current_hp)
             member_id = member.get("id") or member.get("name")
-            if member_id is not None and hp_current is None:
+            if member_id is not None and current_hp is None:
                 mapped = current_hp_map.get(str(member_id))
                 if mapped is not None:
-                    hp_current = mapped
-            if hp_max is not None:
+                    current_hp = mapped
+            if max_hp is not None:
                 try:
-                    hp_max = int(hp_max)
+                    max_hp = int(max_hp)
                 except (TypeError, ValueError):
-                    hp_max = None
-            if hp_current is not None:
+                    max_hp = None
+            if current_hp is not None:
                 try:
-                    hp_current = int(hp_current)
+                    current_hp = int(current_hp)
                 except (TypeError, ValueError):
-                    hp_current = None
-            if hp_max is not None:
-                member["hp_max"] = hp_max
-            if hp_current is not None:
-                member["hp_current"] = hp_current
+                    current_hp = None
+            if max_hp is not None:
+                member["max_hp"] = max_hp
+            if current_hp is not None:
+                member["current_hp"] = current_hp
             if "class_" in member and "class" not in member:
                 member["class"] = member["class_"]
             party.append(member)

--- a/grimbrain/scripts/campaign_play.py
+++ b/grimbrain/scripts/campaign_play.py
@@ -289,8 +289,8 @@ def _state_to_document(state: EngineCampaignState) -> CampaignDocument:
         base = asdict(pm)
         member_full = dict(base)
         hp_current = state.current_hp.get(pm.id, pm.max_hp)
-        member_full["hp_max"] = pm.max_hp
-        member_full["hp_current"] = hp_current
+        member_full["max_hp"] = pm.max_hp
+        member_full["current_hp"] = hp_current
         member_full["hp"] = {"max": pm.max_hp, "current": hp_current}
         members_full.append(member_full)
 
@@ -550,8 +550,8 @@ def sample(
                     "ac": 14,
                     "pb": 2,
                     "speed": 30,
-                    "hp_max": 12,
-                    "hp_current": 12,
+                    "max_hp": 12,
+                    "current_hp": 12,
                 }
             )
             return members
@@ -594,8 +594,8 @@ def sample(
                     "ac": 12,
                     "pb": 2,
                     "speed": 30,
-                    "hp_max": hp_max,
-                    "hp_current": hp_current,
+                    "max_hp": hp_max,
+                    "current_hp": hp_current,
                 }
             )
         return members
@@ -636,15 +636,15 @@ def sample(
     current_hp: dict[str, int] = {}
     for member in members:
         doc = dict(member)
-        hp_max = int(doc.get("hp_max", doc.get("max_hp", 12)))
-        hp_current = int(doc.get("hp_current", hp_max))
-        doc["hp_max"] = hp_max
-        doc["hp_current"] = hp_current
-        doc["hp"] = {"max": hp_max, "current": hp_current}
+        max_hp = int(doc.get("max_hp", doc.get("hp_max", 12)))
+        current_hp_value = int(doc.get("current_hp", doc.get("hp_current", max_hp)))
+        doc["max_hp"] = max_hp
+        doc["current_hp"] = current_hp_value
+        doc["hp"] = {"max": max_hp, "current": current_hp_value}
         member_docs.append(doc)
         member_id = doc.get("id")
         if member_id:
-            current_hp[str(member_id)] = hp_current
+            current_hp[str(member_id)] = current_hp_value
 
     state: dict[str, Any] = {
         "seed": random.randint(0, 1_000_000_000),

--- a/tests/cli/test_campaign_io.py
+++ b/tests/cli/test_campaign_io.py
@@ -34,7 +34,7 @@ def test_load_json_normalizes_legacy(tmp_path):
     assert state["location"] == "Greenfields: Village Gate"
     assert state["gold"] == 12
     assert state["inventory"] == {"torch": 2, "rations": 1}
-    assert state["party"][0]["hp_current"] == 7
+    assert state["party"][0]["current_hp"] == 7
     assert state["current_hp"]["PC1"] == 7
 
 
@@ -51,8 +51,8 @@ def test_save_and_reload_roundtrip(tmp_path):
             {
                 "id": "PC1",
                 "name": "Ranger",
-                "hp_max": 14,
-                "hp_current": 11,
+                "max_hp": 14,
+                "current_hp": 11,
                 "dex_mod": 3,
             }
         ],
@@ -66,7 +66,7 @@ def test_save_and_reload_roundtrip(tmp_path):
     assert reloaded["seed"] == 9
     assert reloaded["day"] == 2
     assert reloaded["time_of_day"] == "afternoon"
-    assert reloaded["party"][0]["hp_current"] == 11
+    assert reloaded["party"][0]["current_hp"] == 11
     assert reloaded["current_hp"]["PC1"] == 11
     assert reloaded["flags"]["mode"] == "solo"
     assert reloaded["journal"] == ["entry"]

--- a/tests/cli/test_campaign_play_commands.py
+++ b/tests/cli/test_campaign_play_commands.py
@@ -38,8 +38,8 @@ def _baseline_state() -> dict:
                 "ac": 13,
                 "pb": 2,
                 "speed": 30,
-                "hp_max": 12,
-                "hp_current": 12,
+                "max_hp": 12,
+                "current_hp": 12,
             }
         ],
         "current_hp": {"PC1": 12},
@@ -71,7 +71,7 @@ def test_short_rest_updates_hp(tmp_path):
     _require_real_typer()
     path = tmp_path / "state.json"
     state = _baseline_state()
-    state["party"][0]["hp_current"] = 5
+    state["party"][0]["current_hp"] = 5
     state["current_hp"]["PC1"] = 5
     save_campaign(state, path)
 
@@ -87,7 +87,7 @@ def test_long_rest_sets_hp_to_max(tmp_path):
     _require_real_typer()
     path = tmp_path / "state.json"
     state = _baseline_state()
-    state["party"][0]["hp_current"] = 4
+    state["party"][0]["current_hp"] = 4
     state["current_hp"]["PC1"] = 4
     save_campaign(state, path)
 
@@ -95,7 +95,7 @@ def test_long_rest_sets_hp_to_max(tmp_path):
     assert result.exit_code == 0
 
     reloaded = cp.load_campaign(path)
-    assert reloaded["current_hp"]["PC1"] == reloaded["party"][0]["hp_max"]
+    assert reloaded["current_hp"]["PC1"] == reloaded["party"][0]["max_hp"]
 
 
 def test_travel_advances_time(tmp_path, monkeypatch):

--- a/tests/cli/test_campaign_play_sample.py
+++ b/tests/cli/test_campaign_play_sample.py
@@ -95,9 +95,9 @@ def test_sample_switches_and_parse(tmp_path):
     assert inv["rope"] == 1
     members = data["party"]
     assert members[0]["name"] == "Anya"
-    assert members[0]["hp_current"] == 6
+    assert members[0]["current_hp"] == 6
     assert members[1]["name"] == "Borin"
-    assert members[1]["hp_max"] == 12
+    assert members[1]["max_hp"] == 12
     assert data["party_info"]["gold"] == 25
     assert len(data["party_info"]["members"]) == 2
 

--- a/tests/models/test_campaign_state_dict_roundtrip.py
+++ b/tests/models/test_campaign_state_dict_roundtrip.py
@@ -9,7 +9,7 @@ def test_campaignstate_roundtrip_basic():
         location="Wilderness",
         gold=7,
         inventory={"rations": 3},
-        party=[{"id": "Aria", "name": "Aria", "hp_max": 11, "hp_current": 11}],
+        party=[{"id": "Aria", "name": "Aria", "max_hp": 11, "current_hp": 11}],
         style="classic",
         flags={"mode": "solo"},
         journal=["entry"],
@@ -19,7 +19,7 @@ def test_campaignstate_roundtrip_basic():
     assert st2.day == 2
     assert st2.time_of_day == "afternoon"
     assert st2.party[0]["name"] == "Aria"
-    assert st2.party[0]["hp_current"] == 11
+    assert st2.party[0]["current_hp"] == 11
     assert st2.flags["mode"] == "solo"
     assert st2.journal == ["entry"]
 
@@ -49,4 +49,4 @@ def test_from_dict_legacy_shapes():
     assert st.location == "Village Gate"
     assert st.gold == 12
     assert st.party[0]["name"] == "Scout"
-    assert st.party[0]["hp_current"] == 8
+    assert st.party[0]["current_hp"] == 8

--- a/tests/models/test_campaign_state_roundtrip.py
+++ b/tests/models/test_campaign_state_roundtrip.py
@@ -9,7 +9,7 @@ def test_campaign_state_roundtrip_simple():
         location="Greenfields: Village Gate",
         gold=50,
         inventory={"rations": 5},
-        party=[{"id": "PC1", "name": "Rin", "hp_max": 10, "hp_current": 8}],
+        party=[{"id": "PC1", "name": "Rin", "max_hp": 10, "current_hp": 8}],
         style="grim",
         flags={"blessed": True},
         journal=[{"day": 3, "note": "Arrived"}],
@@ -20,6 +20,6 @@ def test_campaign_state_roundtrip_simple():
     assert st2.day == st.day
     assert st2.time_of_day == st.time_of_day
     assert st2.party[0]["id"] == st.party[0]["id"]
-    assert st2.party[0]["hp_current"] == 8
+    assert st2.party[0]["current_hp"] == 8
     assert st2.flags == {"blessed": True}
     assert st2.journal == [{"day": 3, "note": "Arrived"}]


### PR DESCRIPTION
## Summary
- normalize campaign loading so party members rename legacy hp_max/current_hp fields before PartyMemberRef construction
- emit max_hp/current_hp consistently from campaign_io and the campaign_play CLI while keeping backward compatibility
- update samples and tests to expect the new field names

## Testing
- pytest tests/phase15/test_style_flag.py::test_status_persists_global_style -q --cov-fail-under=0
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68dd43f5fb648327bb3bf08a3353a3c6